### PR TITLE
Switch @claude to agent mode with issue→PR machinery

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,6 +23,15 @@ on:
     #   - "src/**/*.tsx"
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
+  # Allow claude.yml to dispatch a fresh review (e.g. after an @claude run
+  # pushes commits, or on an `@claude review` comment). GITHUB_TOKEN pushes
+  # don't fire `synchronize`, so an explicit dispatch path is needed.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number to review'
+        required: true
+        type: number
 
 # Serialize reviews per PR: a newer push cancels the in-progress review
 # of the now-stale diff so only the freshest review runs (and posts a
@@ -30,21 +39,29 @@ on:
 # rme review workflow, this one is read-only (its allowedTools below
 # grant no git push / commit), so it never pushes a fix and therefore
 # can't trigger the self-cancellation that rme had to guard against
-# with a conditional expression (see d-morrison/rme#817).
+# with a conditional expression (see d-morrison/rme#817). The
+# `|| inputs.pr_number` keeps a workflow_dispatch review in the same
+# group as the PR's pull_request reviews so they dedupe.
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number }}
+  group: claude-review-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Skip drafts, Dependabot bumps, and fork PRs. Fork PRs can't read repo
-    # secrets, so `CLAUDE_CODE_OAUTH_TOKEN` would be empty and the run would
-    # fail with a noisy red check — bail early instead.
+    # workflow_dispatch is fired by claude.yml for a specific PR, so always
+    # run it. Otherwise skip drafts, Dependabot bumps, and fork PRs (fork
+    # PRs can't read repo secrets, so CLAUDE_CODE_OAUTH_TOKEN would be empty
+    # and the run would fail with a noisy red check).
     if: |
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.user.login != 'dependabot[bot]' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.draft == false &&
+       github.event.pull_request.user.login != 'dependabot[bot]' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
+    env:
+      # Resolve the PR number once: from the pull_request event, or the
+      # workflow_dispatch input when claude.yml triggered us.
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
     permissions:
       contents: read
       pull-requests: write  # post review + inline comments
@@ -71,9 +88,14 @@ jobs:
           # upstream code-review skill; pin to a tag if reviews ever start
           # changing in surprising ways.
           plugins: 'code-review@claude-code-plugins'
-          track_progress: 'true'
+          # track_progress forces tag mode (guaranteed tracking comment),
+          # but the action rejects it for workflow_dispatch events
+          # ("track_progress is only supported for events: pull_request,
+          # issues, ..."). Gate on event_name: tag mode for pull_request,
+          # agent mode for dispatched runs. (See d-morrison/rme#818.)
+          track_progress: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
           prompt: |
-            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+            /code-review:code-review ${{ github.repository }}/pull/${{ env.PR_NUMBER }}
 
             In addition to the standard checks above, this is the qwt Quarto
             website template — small, prose-heavy, and re-used as a template

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -49,9 +49,12 @@ concurrency:
 jobs:
   claude-review:
     # workflow_dispatch is fired by claude.yml for a specific PR, so always
-    # run it. Otherwise skip drafts, Dependabot bumps, and fork PRs (fork
-    # PRs can't read repo secrets, so CLAUDE_CODE_OAUTH_TOKEN would be empty
-    # and the run would fail with a noisy red check).
+    # run it — this intentionally bypasses the draft guard below so a review
+    # fires on the draft PR claude.yml opens for an issue trigger (we want to
+    # review Claude's draft work early). Otherwise skip drafts, Dependabot
+    # bumps, and fork PRs (fork PRs can't read repo secrets, so
+    # CLAUDE_CODE_OAUTH_TOKEN would be empty and the run would fail with a
+    # noisy red check).
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.draft == false &&

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -62,7 +62,11 @@ jobs:
       pull-requests: write  # so Claude can open / edit PRs
       issues: write         # so Claude can comment on issues
       id-token: write
-      actions: read         # so Claude can read CI results on PRs
+      actions: write        # read CI results on PRs AND dispatch
+                            # claude-code-review.yml via `gh workflow run`
+                            # (workflow_dispatch needs actions: write — with
+                            # only `read`, the dispatch 403s and the review
+                            # routing silently fails)
 
     steps:
       # Post a visible acknowledgment BEFORE the multi-minute R/Quarto
@@ -305,9 +309,11 @@ jobs:
           gh workflow run claude-code-review.yml -f pr_number="$PR_NUMBER" \
             || echo "::warning::Could not dispatch claude-code-review.yml; review will not auto-run."
 
-      # When Claude pushed new commits to a PR, re-request review and
-      # dispatch a fresh code review on the new diff.
-      - name: Re-request review and dispatch code review if Claude pushed commits
+      # When Claude pushed new commits to a PR, dispatch a fresh code
+      # review on the new diff. (Unlike rme, this does not re-request a
+      # human reviewer via the requested_reviewers API — qwt has no
+      # standing-reviewer convention; add that here if one is adopted.)
+      - name: Dispatch code review if Claude pushed commits
         if: always() && (github.event.pull_request.number || github.event.issue.pull_request) && steps.head_before.outputs.sha != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -368,10 +374,13 @@ jobs:
               --title "$PR_TITLE" \
               --body "$PR_BODY")
             echo "Opened draft PR: $PR_URL"
-            gh workflow run claude-code-review.yml -f pr_number="${PR_URL##*/}" \
-              || echo "::warning::Could not dispatch claude-code-review.yml."
             PR_VERB="opened draft PR"
           fi
+          # Dispatch a review on the new commits, for both the freshly-opened
+          # and the already-exists (idempotent re-run) paths. The review's
+          # own concurrency group dedupes a redundant dispatch.
+          gh workflow run claude-code-review.yml -f pr_number="${PR_URL##*/}" \
+            || echo "::warning::Could not dispatch claude-code-review.yml."
           gh issue comment "$ISSUE_NUMBER" \
             --body "Pushed Claude's commits to \`${BRANCH}\` and ${PR_VERB}: ${PR_URL}" \
             || echo "::warning::Could not post PR link as issue comment."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -168,8 +168,8 @@ jobs:
               and do NOT run `gh pr create` — a post-step pushes this branch
               and opens a draft PR linking back to the issue.
             - **PR triggers**: commit your changes; they belong on the PR's
-              branch. A post-step re-requests review and dispatches a code
-              review when the head SHA moves.
+              branch. A post-step dispatches a code review when the head SHA
+              moves.
 
             If your reply is **prose** (answering a question, a
             recommendation, a review) rather than a code change, write your
@@ -288,7 +288,7 @@ jobs:
           … (response truncated at ${MAX_LEN} bytes; full text in the [workflow run](${RUN_URL}))"
           fi
 
-          gh issue comment "$ENTITY_NUMBER" --body "$(printf '%s\n\n<sub>— posted by @claude post-step from [workflow run](%s)</sub>\n' "$RESPONSE" "$RUN_URL")" \
+          gh issue comment "$ENTITY_NUMBER" --repo "${{ github.repository }}" --body "$(printf '%s\n\n<sub>— posted by @claude post-step from [workflow run](%s)</sub>\n' "$RESPONSE" "$RUN_URL")" \
             || echo "::warning::Could not post Claude's response back to the source thread."
 
       # Route an explicit `@claude review` request to the dedicated reviewer
@@ -363,6 +363,10 @@ jobs:
             PR_URL="$EXISTING"
             PR_VERB="pushed new commits to existing draft PR"
           else
+            # "Addresses #N" (not "Closes/Fixes #N") is deliberate: this is a
+            # draft of Claude's attempt and may not fully resolve the issue,
+            # so we don't want merging it to auto-close the issue. A human can
+            # switch to "Closes" on the PR if the work is in fact complete.
             PR_BODY=$(printf 'Draft PR opened by `@claude` to address #%s.\n\nTriggered by [workflow run](%s).\n\nAddresses #%s.\n' \
               "$ISSUE_NUMBER" "$RUN_URL" "$ISSUE_NUMBER")
             if [ -z "$ISSUE_TITLE" ]; then
@@ -384,6 +388,6 @@ jobs:
           # own concurrency group dedupes a redundant dispatch.
           gh workflow run claude-code-review.yml -f pr_number="${PR_URL##*/}" \
             || echo "::warning::Could not dispatch claude-code-review.yml."
-          gh issue comment "$ISSUE_NUMBER" \
+          gh issue comment "$ISSUE_NUMBER" --repo "${{ github.repository }}" \
             --body "Pushed Claude's commits to \`${BRANCH}\` and ${PR_VERB}: ${PR_URL}" \
             || echo "::warning::Could not post PR link as issue comment."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,12 +1,23 @@
-# Claude Code GitHub Action
+# Claude Code GitHub Action (agent mode)
 #
-# Responds to "@claude" mentions in issues, issue comments, PR review comments,
-# and PR reviews. Requires the CLAUDE_CODE_OAUTH_TOKEN repository secret (set
-# up by `/install-github-app` from Claude Code, or manually in repo settings).
+# Responds to "@claude" mentions in issues, issue comments, PR review
+# comments, and PR reviews. Requires the CLAUDE_CODE_OAUTH_TOKEN secret.
+#
+# This workflow runs the action in AGENT mode (a `prompt:` is set below).
+# Agent mode does NOT run the action's built-in branch-setup / git-push /
+# response-comment machinery that tag mode provides, so this workflow
+# reproduces it with explicit pre/post steps:
+#   - "Set up branch for issue trigger" creates claude/issue-N-<ts>.
+#   - "Push branch and open draft PR for issue trigger" pushes it + opens
+#     a draft PR, so an @claude mention on an *issue* yields a PR.
+#   - "Post Claude's response if no code was committed" surfaces prose
+#     replies (questions/reviews) that agent mode would otherwise discard.
+#   - "Dispatch claude-code-review.yml on @claude review" routes review
+#     requests to the dedicated reviewer instead of self-reviewing.
+# Ported from d-morrison/rme (#788/#794/#805); adapted to qwt's lighter
+# setup (DESCRIPTION-based deps, no renv; no submodule-token URL rewrite).
 #
 # Project guidance for Claude lives in CLAUDE.md at the repo root.
-#
-# Upstream template: https://github.com/anthropics/claude-code-action
 
 name: Claude Code
 
@@ -25,6 +36,16 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Serialize @claude sessions per issue/PR so rapid mentions don't fire
+# competing runs that race to push the same branch. `cancel-in-progress:
+# false` queues a new mention behind the running session rather than
+# killing it. `|| github.run_id` is a defensive fallback so an unexpected
+# event with no issue/PR number doesn't collapse the group to `claude-`
+# and serialize every session globally.
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   claude:
     # Only trigger for trusted authors (OWNER / MEMBER / COLLABORATOR).
@@ -42,68 +63,315 @@ jobs:
       issues: write         # so Claude can comment on issues
       id-token: write
       actions: read         # so Claude can read CI results on PRs
+
     steps:
+      # Post a visible acknowledgment BEFORE the multi-minute R/Quarto
+      # setup begins, so the user knows the @claude mention was received.
+      # `continue-on-error` keeps a transient comment-API hiccup from
+      # failing the whole run. Posted by github-actions[bot], so it does
+      # not re-trigger this workflow (the if: gate keys on `@claude`).
+      - name: Acknowledge @claude mention
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUM: ${{ github.event.issue.number || github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue comment "$NUM" --repo "${{ github.repository }}" \
+            --body ":eyes: Picked up by [workflow run #${{ github.run_id }}]($RUN_URL). R/Quarto setup runs first; Claude itself responds after that."
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
           submodules: recursive
 
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          tinytex: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: |
+            any::knitr
+            any::rmarkdown
+            any::tibble
+
+      # Record the PR's head SHA before Claude runs (PR triggers only), so
+      # the post-steps can tell whether Claude pushed new commits.
+      - name: Capture PR head SHA before Claude
+        id: head_before
+        if: github.event.pull_request.number || github.event.issue.pull_request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          SHA=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      # Create a feature branch for issue triggers so Claude's commits land
+      # somewhere durable. Agent mode skips the action's built-in
+      # setup-branch step, so without this an @claude mention on an issue
+      # would edit files on the ephemeral checkout and lose them at runner
+      # cleanup. The "Push branch and open draft PR" post-step pushes this
+      # branch and opens the PR. Only fires for issue / issue-comment-on-
+      # issue events (PR triggers commit to the PR's own branch).
+      - name: Set up branch for issue trigger
+        id: issue_branch
+        if: |
+          github.event_name == 'issues' ||
+          (github.event_name == 'issue_comment' && !github.event.issue.pull_request)
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          BRANCH="claude/issue-${ISSUE_NUMBER}-$(date -u +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "starting_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "Created and switched to $BRANCH"
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
-        # Export GH_TOKEN so the `gh` CLI commands granted in claude_args
-        # below (`gh pr create`, `gh pr edit`, `gh pr view`, etc.)
-        # authenticate non-interactively. Without it, `gh` falls back to
-        # an interactive auth prompt and fails in CI, blocking the
-        # branch/PR creation this workflow is meant to enable. The token
-        # is the job's write-scoped GITHUB_TOKEN (see permissions: above);
-        # matches how the repo's other gh-using workflows authenticate.
+        # GH_TOKEN authenticates the `gh` commands granted in claude_args
+        # (gh pr create/edit/view); without it `gh` prompts and fails in CI.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Note: `actions: read` for CI-result inspection is granted at the
-          # job-level `permissions:` block above; we don't need to repeat it
-          # via the action's `additional_permissions` input.
+          # Setting `prompt:` puts the action in AGENT mode (see header).
+          # The triggering comment/issue body is already supplied to Claude
+          # by the action's default prompt; this only adds the workflow's
+          # own operating instructions.
+          prompt: |
+            You were triggered by an @claude mention in a
+            ${{ github.event_name }} event. Address the request in the
+            triggering comment / issue / review.
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+            Git & PR handling (a workflow step does the pushing/PR-opening,
+            not you):
+            - **Issue triggers**: a fresh `claude/issue-N-<timestamp>`
+              branch has already been created and checked out for you. Make
+              your edits and `git commit` them. Do NOT create another branch
+              and do NOT run `gh pr create` — a post-step pushes this branch
+              and opens a draft PR linking back to the issue.
+            - **PR triggers**: commit your changes; they belong on the PR's
+              branch. A post-step re-requests review and dispatches a code
+              review when the head SHA moves.
 
-          # Allow the git/gh commands Claude needs to push a branch and open a
-          # PR, plus the helpers most useful on this Quarto/R repo. `git push`
-          # is narrowed to `origin` and destructive flag variants are
-          # disallowed so a write-scoped GITHUB_TOKEN can't be used to rewrite
-          # or remove refs. The `+ref` force-update refspec is also denied;
-          # the `:ref` delete-refspec form can't be expressed in Claude Code's
-          # pattern syntax (a trailing `:*` is an alias for trailing ` *` —
-          # see https://code.claude.com/docs/en/permissions#wildcard-patterns)
-          # so destructive deletes are caught instead by GitHub branch
-          # protection on the default branch.
-          #
-          # `Rscript -e` is restricted to specific safe namespaces — a bare
-          # `Rscript -e *` would let Claude shell out via `system()` and
-          # bypass the git-push deny list. Extend this list if a workflow
-          # legitimately needs another helper (e.g. `roxygen2::*`).
-          #
-          # `quarto render`/`check` ARE allowed so @claude can confirm the
-          # site still builds before pushing edits to source files —
-          # otherwise a broken render would only surface as a red check on
-          # the PR it opens, after the session has ended and with no chance
-          # to self-correct.
-          #
-          # Note this means the git-push deny list below is not an airtight
-          # seal: `quarto render`, like the already-allowed `devtools::check*`
-          # and `pkgdown::build*`, evaluates project R code that can
-          # `system()` out to arbitrary commands. That's an accepted trade —
-          # the real containment is the trusted-author gate in the job `if:`
-          # above (only OWNER/MEMBER/COLLABORATOR can trigger this run), and
-          # the deny list still blocks Claude's *direct* destructive git
-          # invocations. For airtight isolation you'd render in a separate
-          # read-only job; we prefer in-session render verification here.
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options.
+            If your reply is **prose** (answering a question, a
+            recommendation, a review) rather than a code change, write your
+            final message as the reply you want posted on the thread — a
+            post-step posts it as a comment when you didn't commit code.
+
+            For an explicit `@claude review` request, do NOT post your own
+            review; a post-step dispatches the dedicated code-review
+            workflow instead.
+
+          # Allowed git/gh/quarto/Rscript commands. `git push` is narrowed to
+          # `origin` and destructive flag/refspec variants are denied so the
+          # write-scoped token can't rewrite or delete refs. `Rscript -e` is
+          # restricted to specific namespaces. `quarto render`/`check` are
+          # allowed so Claude can confirm the site builds before pushing —
+          # accepting that quarto (like devtools::check/pkgdown::build) runs
+          # project R code that can `system()`; the real containment is the
+          # trusted-author gate in the job `if:` above.
           claude_args: |
-            --allowedTools "Bash(Rscript -e 'lintr::lint*'),Bash(Rscript -e 'devtools::check*'),Bash(Rscript -e 'devtools::document*'),Bash(Rscript -e 'pkgdown::build*'),Bash(quarto render:*),Bash(quarto check:*),Bash(git diff:*),Bash(git log:*),Bash(git status:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push origin:*),Bash(git push -u origin:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue view:*)" --disallowedTools "Bash(git push --force:*),Bash(git push -f:*),Bash(git push --delete:*),Bash(git push -d:*),Bash(git push --mirror:*),Bash(git push --tags:*),Bash(git push --all:*),Bash(git push origin +*),Bash(git push -u origin +*)"
+            --allowedTools "Bash(Rscript -e 'lintr::lint*'),Bash(Rscript -e 'devtools::check*'),Bash(Rscript -e 'devtools::document*'),Bash(Rscript -e 'pkgdown::build*'),Bash(quarto render:*),Bash(quarto check:*),Bash(git diff:*),Bash(git log:*),Bash(git status:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push origin:*),Bash(git push -u origin:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue view:*)" --disallowedTools "Bash(git push --force:*),Bash(git push -f:*),Bash(git push --delete:*),Bash(git push -d:*),Bash(git push --mirror:*),Bash(git push --tags:*),Bash(git push --all:*),Bash(git push origin +*),Bash(git push -u origin +*)"
 
+      # Fetch the PR's head SHA once, post-Claude, for the two steps that
+      # both need it (the prose-post COMMITTED check and the re-request
+      # step). PR-context only; mirrors the before-step above.
+      - name: Capture PR head SHA after Claude
+        id: head_after
+        if: always() && (github.event.pull_request.number || github.event.issue.pull_request)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          SHA=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      # Surface Claude's final prose reply when it didn't commit code.
+      # Agent mode discards the response otherwise. Skipped on `@claude
+      # review` (with PR context) because the dispatch step below routes
+      # that to the dedicated reviewer — posting here too would double up.
+      # The PR-context guard keeps `@claude review` on a plain issue from
+      # falling into the skip (no PR to dispatch a review for).
+      - name: Post Claude's response if no code was committed
+        if: |
+          always() &&
+          steps.claude.outcome == 'success' &&
+          !(
+            (
+              contains(github.event.comment.body, '@claude review') ||
+              contains(github.event.review.body, '@claude review')
+            ) &&
+            (github.event.pull_request.number || github.event.issue.pull_request)
+          )
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENTITY_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+          ISSUE_BRANCH_STARTING_SHA: ${{ steps.issue_branch.outputs.starting_sha }}
+          PR_HEAD_BEFORE: ${{ steps.head_before.outputs.sha }}
+          PR_HEAD_AFTER: ${{ steps.head_after.outputs.sha }}
+        run: |
+          # Did Claude commit anything? Issue triggers: local HEAD vs the
+          # pre-step's recorded tip. PR triggers: PR head SHA before vs
+          # after. Either guard requires a non-empty "after" so a failed
+          # SHA fetch doesn't get misread as "committed" (which would
+          # wrongly suppress the prose post).
+          COMMITTED=false
+          if [ -n "$ISSUE_BRANCH_STARTING_SHA" ]; then
+            [ "$(git rev-parse HEAD)" != "$ISSUE_BRANCH_STARTING_SHA" ] && COMMITTED=true
+          fi
+          if [ -n "$PR_HEAD_BEFORE" ] && [ -n "$PR_HEAD_AFTER" ] && [ "$PR_HEAD_AFTER" != "$PR_HEAD_BEFORE" ]; then
+            COMMITTED=true
+          fi
+          if [ "$COMMITTED" = "true" ]; then
+            echo "Claude committed code; commits are the deliverable, skipping response-text post."
+            exit 0
+          fi
+
+          FILE="${EXECUTION_FILE:-/home/runner/work/_temp/claude-execution-output.json}"
+          if [ ! -f "$FILE" ]; then
+            echo "::warning::No Claude execution output at $FILE; nothing to post."
+            exit 0
+          fi
+
+          # execution_file is a single JSON array of event objects. flatten(1)
+          # collapses the slurp wrap so we iterate event objects whether the
+          # file is one array (real), NDJSON, or has a stray array element;
+          # the type=="object" guard skips non-objects before `.type`.
+          ASSISTANT_COUNT=$(jq -rs 'flatten(1) | [.[] | select(type == "object" and .type == "assistant")] | length' < "$FILE")
+          if [ "$ASSISTANT_COUNT" = "0" ]; then
+            echo "::warning::No assistant-typed events in $FILE — action output schema may have changed. Nothing to post."
+            exit 0
+          fi
+          RESPONSE=$(jq -rs '
+            flatten(1)
+            | [.[] | select(type == "object" and .type == "assistant")]
+            | last
+            | (.message.content // [])
+            | map(select(.type == "text") | .text)
+            | join("\n\n")
+          ' < "$FILE")
+          if [ -z "$RESPONSE" ] || [ "$RESPONSE" = "null" ]; then
+            echo "::warning::Assistant events present but no text content; nothing to post."
+            exit 0
+          fi
+
+          # GitHub comment bodies cap at 65,536 bytes; truncate by bytes
+          # (wc -c / head -c, not bash ${#} which counts characters).
+          MAX_LEN=60000
+          BYTE_LEN=$(printf '%s' "$RESPONSE" | wc -c)
+          if [ "$BYTE_LEN" -gt "$MAX_LEN" ]; then
+            RESPONSE="$(printf '%s' "$RESPONSE" | head -c "$MAX_LEN")
+
+          … (response truncated at ${MAX_LEN} bytes; full text in the [workflow run](${RUN_URL}))"
+          fi
+
+          gh issue comment "$ENTITY_NUMBER" --body "$(printf '%s\n\n<sub>— posted by @claude post-step from [workflow run](%s)</sub>\n' "$RESPONSE" "$RUN_URL")" \
+            || echo "::warning::Could not post Claude's response back to the source thread."
+
+      # Route an explicit `@claude review` request to the dedicated reviewer
+      # workflow rather than letting the agent self-review (which would
+      # double up with claude-code-review.yml's own push-triggered run).
+      # No outcome guard: a review dispatch doesn't depend on the agent's
+      # output, so fire it even if the agent step was skipped/cancelled.
+      - name: Dispatch claude-code-review.yml on @claude review comment
+        if: |
+          always() &&
+          (github.event.pull_request.number || github.event.issue.pull_request) &&
+          (
+            contains(github.event.comment.body, '@claude review') ||
+            contains(github.event.review.body, '@claude review')
+          )
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          echo "Dispatching claude-code-review.yml for PR #$PR_NUMBER (@claude review comment)."
+          gh workflow run claude-code-review.yml -f pr_number="$PR_NUMBER" \
+            || echo "::warning::Could not dispatch claude-code-review.yml; review will not auto-run."
+
+      # When Claude pushed new commits to a PR, re-request review and
+      # dispatch a fresh code review on the new diff.
+      - name: Re-request review and dispatch code review if Claude pushed commits
+        if: always() && (github.event.pull_request.number || github.event.issue.pull_request) && steps.head_before.outputs.sha != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA_BEFORE: ${{ steps.head_before.outputs.sha }}
+          SHA_AFTER: ${{ steps.head_after.outputs.sha }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          echo "before=$SHA_BEFORE  after=$SHA_AFTER"
+          if [ -n "$SHA_AFTER" ] && [ "$SHA_AFTER" != "$SHA_BEFORE" ]; then
+            echo "Claude pushed new commits; dispatching code review."
+            gh workflow run claude-code-review.yml -f pr_number="$PR_NUMBER" \
+              || echo "::warning::Could not dispatch claude-code-review.yml."
+          else
+            echo "No new commits on PR head; skipping review dispatch."
+          fi
+
+      # Pair to "Set up branch for issue trigger": push the branch Claude
+      # committed to and open a draft PR. Runs on always() so partial work
+      # is preserved even if the Claude step failed. qwt's checkout uses the
+      # persisted GITHUB_TOKEN (no submodule-token URL rewrite), so a plain
+      # `git push origin` authenticates — no token-bearing URL needed.
+      - name: Push branch and open draft PR for issue trigger
+        if: |
+          always() &&
+          steps.issue_branch.outputs.branch != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.issue_branch.outputs.branch }}
+          STARTING_SHA: ${{ steps.issue_branch.outputs.starting_sha }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          CURRENT_SHA=$(git rev-parse HEAD)
+          if [ "$CURRENT_SHA" = "$STARTING_SHA" ]; then
+            echo "No new commits on $BRANCH — Claude produced no changes; skipping push/PR."
+            exit 0
+          fi
+          echo "Pushing $BRANCH ($STARTING_SHA -> $CURRENT_SHA)"
+          git push origin "$BRANCH"
+          EXISTING=$(gh pr list --head "$BRANCH" --state open --json url --jq '.[0].url // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "PR already exists for $BRANCH: $EXISTING"
+            PR_URL="$EXISTING"
+            PR_VERB="pushed new commits to existing draft PR"
+          else
+            PR_BODY=$(printf 'Draft PR opened by `@claude` to address #%s.\n\nTriggered by [workflow run](%s).\n\nAddresses #%s.\n' \
+              "$ISSUE_NUMBER" "$RUN_URL" "$ISSUE_NUMBER")
+            if [ -z "$ISSUE_TITLE" ]; then
+              PR_TITLE="Claude response to issue #${ISSUE_NUMBER}"
+            else
+              PR_TITLE="$ISSUE_TITLE"
+            fi
+            PR_URL=$(gh pr create \
+              --base "${{ github.event.repository.default_branch }}" \
+              --head "$BRANCH" \
+              --draft \
+              --title "$PR_TITLE" \
+              --body "$PR_BODY")
+            echo "Opened draft PR: $PR_URL"
+            gh workflow run claude-code-review.yml -f pr_number="${PR_URL##*/}" \
+              || echo "::warning::Could not dispatch claude-code-review.yml."
+            PR_VERB="opened draft PR"
+          fi
+          gh issue comment "$ISSUE_NUMBER" \
+            --body "Pushed Claude's commits to \`${BRANCH}\` and ${PR_VERB}: ${PR_URL}" \
+            || echo "::warning::Could not post PR link as issue comment."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -276,11 +276,14 @@ jobs:
           fi
 
           # GitHub comment bodies cap at 65,536 bytes; truncate by bytes
-          # (wc -c / head -c, not bash ${#} which counts characters).
+          # (wc -c / head -c, not bash ${#} which counts characters). Pipe
+          # the byte-cut through `iconv -c` to drop a trailing partial
+          # multibyte char, so head -c can't leave invalid UTF-8 that gh
+          # would reject or render as a replacement glyph.
           MAX_LEN=60000
           BYTE_LEN=$(printf '%s' "$RESPONSE" | wc -c)
           if [ "$BYTE_LEN" -gt "$MAX_LEN" ]; then
-            RESPONSE="$(printf '%s' "$RESPONSE" | head -c "$MAX_LEN")
+            RESPONSE="$(printf '%s' "$RESPONSE" | head -c "$MAX_LEN" | iconv -f UTF-8 -t UTF-8 -c)
 
           … (response truncated at ${MAX_LEN} bytes; full text in the [workflow run](${RUN_URL}))"
           fi


### PR DESCRIPTION
Ports rme's agent-mode `@claude` design to qwt so an `@claude` mention on an **issue** produces a draft PR, and prose replies / review requests are handled cleanly. Adapted to qwt's lighter setup.

## Why agent mode

Setting `prompt:` puts `claude-code-action` in **agent mode**, which skips its built-in branch-setup / git-push / response-comment machinery. This workflow reproduces that machinery with explicit pre/post steps (the same pattern proven in `d-morrison/rme`, PRs #788/#794/#805).

## `claude.yml` changes
- **concurrency group** — serialize `@claude` runs per issue/PR (`cancel-in-progress: false`).
- **ack-mention sticky** — immediate feedback before the R/Quarto setup chain.
- **R + Quarto setup** — so the allowed `quarto render` / `Rscript` tools actually work (DESCRIPTION-based deps, mirroring `preview.yml`; no renv).
- **capture PR head SHA before/after** — to detect whether Claude pushed.
- **Set up branch for issue trigger** — create `claude/issue-N-<timestamp>` so issue-triggered commits land somewhere durable.
- **Post Claude's response if no code committed** — surface prose replies agent mode would otherwise discard (skipped on `@claude review`).
- **Dispatch `claude-code-review.yml` on `@claude review`** — route review requests to the dedicated reviewer instead of self-reviewing. **Fixes the agent+reviewer double-review observed on #72.**
- **Re-request review** when Claude pushed commits to a PR.
- **Push branch and open draft PR for issue trigger** — `git push origin` + `gh pr create --draft`.

## `claude-code-review.yml` changes
- add **`workflow_dispatch`** trigger (+ `pr_number` input) so `claude.yml` can dispatch it
- broaden concurrency group + PR-number resolution with `inputs.pr_number`
- allow `workflow_dispatch` in the job `if:`
- gate `track_progress` on `event_name` (the action rejects it for `workflow_dispatch`)

## qwt-specific adaptations (vs rme)
- DESCRIPTION-based deps, **no renv / JAGS / SymPy / tinytex-heavy stack**
- **no submodule-token URL rewrite**, so a plain `git push origin` authenticates via the persisted checkout token — no token-bearing-URL workaround needed (rme #794)
- **no EPI tokens / stats-allowlist**
- keeps qwt's **author-association trusted-actor gate** and **curated allow/deny tool list**

## Test plan (on qwt — the workflow testbed)
- [ ] `@claude` on a fresh **issue** asking for a small edit → verify a `claude/issue-N-*` branch is pushed and a **draft PR** opens linking back to the issue
- [ ] `@claude <question>` (no code change) → verify Claude's prose reply is **posted as a comment** (not discarded)
- [ ] `@claude review` on a PR → verify the **dedicated reviewer** runs (dispatched) and the agent does **not** post a second review
- [ ] `@claude` on a PR asking for a fix → verify commits land on the PR branch and a fresh review is dispatched
- [ ] Verify a non-collaborator `@claude` mention is still ignored (author gate)
- [ ] Verify `quarto render` works in-session (R/Quarto setup present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)