### PR TITLE
preview: cancel superseded preview builds (concurrency)

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,6 +10,15 @@ on:
       - labeled
       - unlabeled
 
+# Cancel an in-progress preview build when a newer event supersedes it on
+# the same ref — otherwise a fresh push queues behind the stale build and
+# the up-to-date preview is delayed until the obsolete one finishes (see
+# d-morrison/rme#812). `github.ref` is stable across a PR's events, so all
+# of a PR's preview runs share one group.
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-deploy:
     if: |


### PR DESCRIPTION
`preview.yml` had **no concurrency group**, so a fresh push to a PR queued its preview build behind the in-progress (now-stale) one instead of cancelling it — delaying the up-to-date preview.

```yaml
concurrency:
  group: preview-${{ github.ref }}
  cancel-in-progress: true
```

`github.ref` is stable across a PR's events, so all of a PR's preview runs share one group; a newer event cancels the stale build. Ports the rme #812/#816 fix.

## Test plan
- [ ] Push two commits in quick succession to a PR; confirm the first preview build is cancelled rather than both running to completion in sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)