### PR TITLE
Add path-scoped Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,12 @@ The source files for the lab manual are available at <https://github.com/UCD-SER
 For workflow fixes, do not restrict the publish workflow render target to HTML only.
 Keep publish rendering all configured formats and fix underlying failures instead.
 
+Path-scoped rules live in [`.github/instructions/`](instructions/) and attach
+automatically (via each file's `applyTo:` glob) when you edit matching files:
+
+- [`quarto-content.instructions.md`](instructions/quarto-content.instructions.md) — `.qmd` / `.Rmd` content
+- [`r-and-config.instructions.md`](instructions/r-and-config.instructions.md) — `.R`, `.yml`, `.yaml`
+
 ## Style Guidelines
 
 ### Lists

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,8 @@ The source files for the lab manual are available at <https://github.com/UCD-SER
 For workflow fixes, do not restrict the publish workflow render target to HTML only.
 Keep publish rendering all configured formats and fix underlying failures instead.
 
+## Path-Scoped Rules
+
 Path-scoped rules live in [`.github/instructions/`](instructions/) and attach
 automatically (via each file's `applyTo:` glob) when you edit matching files:
 

--- a/.github/instructions/quarto-content.instructions.md
+++ b/.github/instructions/quarto-content.instructions.md
@@ -8,10 +8,10 @@ description: "Use when editing Quarto pages, chapters, slides, handouts, or narr
 - Link to source `.qmd` files, not rendered `.html` files.
 - Always leave a blank line before a markdown bullet list, and use a bullet
   list (not comma-separated prose) for three or more items.
-- Prefer Quarto div wrappers for new figures and tables. Use
-  `#| code-fold: true` on a chunk when the *output* (plot, table) is the point
-  and the code is incidental; do not fold tutorial code, short examples, or
-  chunks where the console output is the main content.
+- Prefer Quarto div wrappers for new figures and tables.
+- Use `#| code-fold: true` on a chunk when the *output* (plot, table) is the
+  point and the code is incidental; do not fold tutorial code, short examples,
+  or chunks where the console output is the main content.
 - Prefer chunk options as YAML-style `#|` directives, not inline
   `r, opt = val` arguments.
 - For a changed `.qmd` with R code, run

--- a/.github/instructions/quarto-content.instructions.md
+++ b/.github/instructions/quarto-content.instructions.md
@@ -1,0 +1,27 @@
+---
+applyTo: "**/*.{qmd,Rmd}"
+description: "Use when editing Quarto pages, chapters, slides, handouts, or narrative content in this repository."
+---
+
+# Quarto Content
+
+- Link to source `.qmd` files, not rendered `.html` files.
+- Always leave a blank line before a markdown bullet list, and use a bullet
+  list (not comma-separated prose) for three or more items.
+- Prefer Quarto div wrappers for new figures and tables. Use
+  `#| code-fold: true` on a chunk when the *output* (plot, table) is the point
+  and the code is incidental; do not fold tutorial code, short examples, or
+  chunks where the console output is the main content.
+- Prefer chunk options as YAML-style `#|` directives, not inline
+  `r, opt = val` arguments.
+- Do not hard-code computed values in narrative text. Compute them in a chunk
+  and reference them with inline R.
+- Treat files under `_extensions/` as vendored third-party code: read them for
+  context if needed, but do not reformat or edit them as part of a content
+  change.
+
+See also:
+
+- [CLAUDE.md](../../CLAUDE.md)
+- [copilot-instructions.md](../copilot-instructions.md)
+- [r-and-config.instructions.md](r-and-config.instructions.md)

--- a/.github/instructions/quarto-content.instructions.md
+++ b/.github/instructions/quarto-content.instructions.md
@@ -14,6 +14,8 @@ description: "Use when editing Quarto pages, chapters, slides, handouts, or narr
   chunks where the console output is the main content.
 - Prefer chunk options as YAML-style `#|` directives, not inline
   `r, opt = val` arguments.
+- For a changed `.qmd` with R code, run
+  `Rscript -e 'lintr::lint("path/to/file.qmd")'` before finishing.
 - Do not hard-code computed values in narrative text. Compute them in a chunk
   and reference them with inline R.
 - Treat files under `_extensions/` as vendored third-party code: read them for

--- a/.github/instructions/r-and-config.instructions.md
+++ b/.github/instructions/r-and-config.instructions.md
@@ -10,7 +10,8 @@ description: "Use when editing R source, Quarto configuration, or GitHub workflo
   relevant workflow file before changing package, render, or CI behavior.
 - Respect [.lintr.R](../../.lintr.R). For changed `.R` files run
   `Rscript -e 'lintr::lint("path/to/file.R")'`; for changed `.qmd` files with R
-  code, lint the `.qmd` file itself.
+  code, lint the `.qmd` file itself. Before finishing, confirm
+  `Rscript -e 'lintr::lint_dir()'` still passes (this is what CI runs).
 - If your change affects rendering, render only the touched page in HTML
   (`quarto render <file>.qmd --to html`), not the full site.
 - Run `Rscript -e 'spelling::spell_check_package()'` before finishing changes to

--- a/.github/instructions/r-and-config.instructions.md
+++ b/.github/instructions/r-and-config.instructions.md
@@ -9,14 +9,13 @@ description: "Use when editing R source, Quarto configuration, or GitHub workflo
   [DESCRIPTION](../../DESCRIPTION), [_quarto.yml](../../_quarto.yml), and the
   relevant workflow file before changing package, render, or CI behavior.
 - Respect [.lintr.R](../../.lintr.R). For changed `.R` files run
-  `Rscript -e 'lintr::lint("path/to/file.R")'`; for changed `.qmd` files with R
-  code, lint the `.qmd` file itself. Before finishing, confirm
+  `Rscript -e 'lintr::lint("path/to/file.R")'`, then confirm
   `Rscript -e 'lintr::lint_dir()'` still passes (this is what CI runs).
-- If your change affects rendering, render only the touched page in HTML
-  (`quarto render <file>.qmd --to html`), not the full site.
+- If a render-affecting config change touches a page, render only that page in
+  HTML (`quarto render <file>.qmd --to html`), not the full site.
 - Run `Rscript -e 'spelling::spell_check_package()'` before finishing changes to
-  `.R`, `.qmd`, or config files. Fix only errors you introduced, and add
-  legitimate technical terms to `inst/WORDLIST` rather than disabling the check.
+  `.R` or config files. Fix only errors you introduced, and add legitimate
+  technical terms to `inst/WORDLIST` rather than disabling the check.
 - This is a template: every dependency added here lands in every downstream
   book, so do not add a new R package or Quarto extension without a clear
   reason. Align workflow and render changes with the existing CI patterns

--- a/.github/instructions/r-and-config.instructions.md
+++ b/.github/instructions/r-and-config.instructions.md
@@ -1,0 +1,33 @@
+---
+applyTo: "**/*.{R,r,yml,yaml}"
+description: "Use when editing R source, Quarto configuration, or GitHub workflow files in this repository."
+---
+
+# R and Config Work
+
+- This repo is both a Quarto project and a small R package. Check
+  [DESCRIPTION](../../DESCRIPTION), [_quarto.yml](../../_quarto.yml), and the
+  relevant workflow file before changing package, render, or CI behavior.
+- Respect [.lintr.R](../../.lintr.R). For changed `.R` files run
+  `Rscript -e 'lintr::lint("path/to/file.R")'`; for changed `.qmd` files with R
+  code, lint the `.qmd` file itself.
+- If your change affects rendering, render only the touched page in HTML
+  (`quarto render <file>.qmd --to html`), not the full site.
+- Run `Rscript -e 'spelling::spell_check_package()'` before finishing changes to
+  `.R`, `.qmd`, or config files. Fix only errors you introduced, and add
+  legitimate technical terms to `inst/WORDLIST` rather than disabling the check.
+- This is a template: every dependency added here lands in every downstream
+  book, so do not add a new R package or Quarto extension without a clear
+  reason. Align workflow and render changes with the existing CI patterns
+  instead of inventing parallel setup.
+- Do not edit generated files (`README.md` is built from `README.Rmd`; `_site/`,
+  `_freeze/`, and `.quarto/` are build outputs).
+
+See also:
+
+- [DESCRIPTION](../../DESCRIPTION)
+- [_quarto.yml](../../_quarto.yml)
+- [CLAUDE.md](../../CLAUDE.md)
+- [lint-project.yaml](../workflows/lint-project.yaml)
+- [preview.yml](../workflows/preview.yml)
+- [copilot-instructions.md](../copilot-instructions.md)


### PR DESCRIPTION
## Summary

Adds GitHub Copilot **path-scoped instructions** under `.github/instructions/`. Each file carries an `applyTo:` glob in its frontmatter, so the rules attach automatically only when matching files are edited — keeping the monolithic `copilot-instructions.md` lean while giving focused, auto-loading guidance.

- `quarto-content.instructions.md` → `**/*.{qmd,Rmd}` — link to source `.qmd` not `.html`, the bullet-list/blank-line rule, `code-fold` discipline, `#|` chunk options, no hard-coded computed values, treat `_extensions/` as vendored.
- `r-and-config.instructions.md` → `**/*.{R,r,yml,yaml}` — respect `.lintr.R`, lint changed files, render only the touched page (not the full site), run `spelling::spell_check_package()`, no new template-wide deps without reason, don't edit generated files.

`copilot-instructions.md` gains a short pointer to the two scoped files.

## Provenance

Pattern ported from `d-morrison/rme` and `ucdavis/bcs`, which both use this `applyTo:`-scoped layout. Repo-specific content from those repos (`_subfiles/` routing, `latex-macros`, `renv`, JAGS) was intentionally dropped — this is a template, so the instructions stay generic to Quarto/R-package work.

## Test plan

- [ ] Confirm both files parse as valid frontmatter + markdown.
- [ ] In a Copilot session, edit a `.qmd` and confirm the quarto-content rules attach; edit a `.R`/`.yml` and confirm the r-and-config rules attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)