### PR TITLE
Add lint-changed-files workflow (PR-scoped linting)

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -1,0 +1,55 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# Lints ONLY the files changed in a PR (diffed against the base via the GitHub
+# API), giving fast feedback that flags newly-introduced lint issues without
+# failing on pre-existing ones elsewhere in the repo. Complements
+# lint-project.yaml, which lints the whole project on push and PR.
+on:
+  pull_request:
+
+name: lint-changed-files.yaml
+
+permissions: read-all
+
+# Cancel a superseded run when a newer commit is pushed to the same PR.
+concurrency:
+  group: lint-changed-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint-changed-files:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install lintr and dependencies
+        run: install.packages(c("lintr", "gh", "purrr", "withr"), repos = "https://packagemanager.posit.co/cran/__linux__/noble/latest")
+        shell: Rscript {0}
+
+      - name: Use the repo's lintr config
+        run: |
+          cat('\noptions(lintr.linter_file = ".lintr.R")\n', file = "~/.Rprofile", append = TRUE)
+        shell: Rscript {0}
+
+      - name: Lint files changed by this PR
+        run: |
+          files <- gh::gh(
+            "GET /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files",
+            .limit = Inf
+          )
+          changed_files <- purrr::map_chr(files, "filename")
+          all_files <- list.files(recursive = TRUE)
+          # lint_dir() lints everything except the exclusions, so exclude every
+          # file that this PR did NOT change.
+          exclusions_list <- as.list(setdiff(all_files, changed_files))
+          lintr::lint_dir(exclusions = exclusions_list)
+        shell: Rscript {0}
+        env:
+          LINTR_ERROR_ON_LINT: true

--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -33,11 +33,9 @@ jobs:
         run: install.packages(c("lintr", "gh", "purrr", "withr"), repos = "https://packagemanager.posit.co/cran/__linux__/noble/latest")
         shell: Rscript {0}
 
-      - name: Use the repo's lintr config
-        run: |
-          cat('\noptions(lintr.linter_file = ".lintr.R")\n', file = "~/.Rprofile", append = TRUE)
-        shell: Rscript {0}
-
+      # No need to set options(lintr.linter_file): lintr auto-detects `.lintr.R`
+      # (find_config() resolves it with no option set), same as
+      # lint-project.yaml's bare lint_dir().
       - name: Lint files changed by this PR
         run: |
           files <- gh::gh(
@@ -45,7 +43,9 @@ jobs:
             .limit = Inf
           )
           changed_files <- purrr::map_chr(files, "filename")
-          all_files <- list.files(recursive = TRUE)
+          # all.files = TRUE so changed dotfiles (e.g. .lintr.R) appear here and
+          # get excluded too, rather than being linted on every PR.
+          all_files <- list.files(recursive = TRUE, all.files = TRUE)
           # lint_dir() lints everything except the exclusions, so exclude every
           # file that this PR did NOT change.
           exclusions_list <- as.list(setdiff(all_files, changed_files))


### PR DESCRIPTION
## Summary

Adds `.github/workflows/lint-changed-files.yaml` — a PR-scoped linter that lints **only the files changed in the PR** (resolved via the GitHub API), giving contributors fast feedback on newly-introduced lint issues without the run failing on pre-existing issues elsewhere in the repo.

It complements the existing `lint-project.yaml` (which lints the whole project on push + PR):

- Uses the same `lintr::lint_dir()` + `.lintr.R` config as `lint-project.yaml` — no `rocker/verse` container and no `R CMD INSTALL .` (those are R-package-specific from the source repo).
- Builds the changed-file set from `pulls/<n>/files`, then excludes every *unchanged* file so only changed `.R`/`.qmd` files are linted.
- Adds a per-PR `concurrency` group so a newer push cancels the superseded run.

## Provenance

Adapted from `d-morrison/rpt`'s `lint-changed-files.yaml`, switched from `lint_package` to `lint_dir` to match qwt's existing lint setup and to cover `.qmd` content, not just package `R/`.

## Test plan

- [ ] Open a PR touching one `.R` or `.qmd` file with a deliberate lint issue → confirm the workflow flags only that file.
- [ ] Confirm a pre-existing lint issue in an unchanged file does **not** fail the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)