### PR TITLE
Install DT so macros-table.qmd renders in CI

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -127,7 +127,7 @@ jobs:
         if: steps.check_label.outputs.skip != 'true'
         run: |
           install.packages(
-            c("lintr", "rmarkdown"),
+            c("lintr", "rmarkdown", "DT"),
             repos = "https://packagemanager.posit.co/cran/__linux__/noble/latest"
           )
         shell: Rscript {0}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -54,6 +54,7 @@ jobs:
             any::knitr
             any::rmarkdown
             any::tibble
+            any::DT
 
       - name: Set timezone to Pacific Time
         run: echo "TZ=America/Los_Angeles" >> $GITHUB_ENV

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,7 @@ jobs:
             any::knitr
             any::rmarkdown
             any::tibble
+            any::DT
 
       - name: Set timezone to Pacific Time
         run: echo "TZ=America/Los_Angeles" >> $GITHUB_ENV


### PR DESCRIPTION
## Problem

`Quarto Publish` has been failing on `main` with:

```
Error in `loadNamespace()`: there is no package called 'DT'
Quitting from macros-table.qmd:166-190 [macros-table]
```

The `macros` submodule's `macros-table.qmd` renders an interactive table via `DT::datatable()` / `DT::JS()`, but `DT` was not installed in any render environment, so `quarto render` aborts. This is a **pre-existing** failure (red on every recent `main` run), unrelated to the recent `.github/` config PRs.

## Fix

Add `DT` to the render-dependency installs:

- `publish.yml` and `preview.yml` — `any::DT` in the `setup-r-dependencies` package list (alongside `knitr`/`rmarkdown`/`tibble`).
- `copilot-setup-steps.yml` — `"DT"` in the `install.packages()` list so the Copilot agent can render locally.

`DT` is a render-content dependency (it comes from the macros submodule's content, not qwt's R-package code), so it lives with the other render deps rather than in `DESCRIPTION`.

## Test plan

- [ ] This PR's `preview.yml` run renders the full site (including `macros-table.qmd`) with `DT` installed — the render step should now pass.
- [ ] After merge, confirm `Quarto Publish` on `main` goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)