### PR TITLE
[CI TEST - do not merge] verify lint-changed-files flags violations

### DIFF
--- a/lint_violation_probe.R
+++ b/lint_violation_probe.R
@@ -1,0 +1,2 @@
+example_value <- c(1, 2, 3)
+totalSum <- example_value %>% sum()


### PR DESCRIPTION
Throwaway PR to verify the `lint-changed-files` workflow flags a deliberate R lint violation (`totalSum` camelCase + `%>%` instead of `|>`) in real CI. Will be closed and the branch deleted once the workflow result is confirmed. Do not merge.