### PR TITLE
Don't render the macros submodule's .qmd files directly

### DIFF
--- a/_quarto-website.yml
+++ b/_quarto-website.yml
@@ -7,6 +7,11 @@ project:
     - "!README.md"
     - "!appendix-document-metadata.qmd"
     - "!references.qmd"
+    # The `macros` git submodule provides macro definitions for include/
+    # shortcode use, not standalone site pages. Don't render its .qmd files
+    # directly: macros-table.qmd uses DT::datatable() (an HTML widget) that
+    # errors when the project also renders to PDF.
+    - "!macros/"
 
 website:
   title: "Quarto Website Template"


### PR DESCRIPTION
## Problem

`Quarto Publish` renders `macros/index.qmd` and `macros/macros-table.qmd` from the `macros` git submodule as standalone site pages (files 5–6 of 7 in the render). `macros-table.qmd` uses `DT::datatable()` (an HTML widget), which errors when the project also renders to PDF:

```
Error: Functions that produce HTML output found in document targeting pdf output.
```

(This surfaced after #82 installed `DT` and the render got past the earlier `no package called 'DT'` error.)

## Fix

Per the request to **not touch the submodule**, exclude its directory from the project render list in `_quarto-website.yml`:

```yaml
render:
  ...
  - "!macros/"
```

The submodule's files remain available as resources for includes/shortcodes (e.g. `macros-table.qmd` still `readLines("macros.qmd")`); they're just no longer rendered as standalone pages. Verified nothing in the qwt site links to the `macros/` pages, so no broken links.

## Test plan

- [ ] This PR's preview render no longer lists `macros/index.qmd` or `macros/macros-table.qmd` (render count drops from 7 to 5).
- [ ] After merge, `Quarto Publish` on `main` goes green (the PDF/HTML-widget error can't occur if the file isn't rendered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)