### PR TITLE
Revert now-unneeded DT install

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -127,7 +127,7 @@ jobs:
         if: steps.check_label.outputs.skip != 'true'
         run: |
           install.packages(
-            c("lintr", "rmarkdown", "DT"),
+            c("lintr", "rmarkdown"),
             repos = "https://packagemanager.posit.co/cran/__linux__/noble/latest"
           )
         shell: Rscript {0}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -54,7 +54,6 @@ jobs:
             any::knitr
             any::rmarkdown
             any::tibble
-            any::DT
 
       - name: Set timezone to Pacific Time
         run: echo "TZ=America/Los_Angeles" >> $GITHUB_ENV

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,6 @@ jobs:
             any::knitr
             any::rmarkdown
             any::tibble
-            any::DT
 
       - name: Set timezone to Pacific Time
         run: echo "TZ=America/Los_Angeles" >> $GITHUB_ENV


### PR DESCRIPTION
## Why

#82 added `DT` to the render-dependency installs (`publish.yml`, `preview.yml`, `copilot-setup-steps.yml`) to fix `macros-table.qmd`'s `DT::datatable()` render.

Since #84 the project no longer renders the `macros` submodule's `.qmd` files, and nothing in the rendered site uses `DT`. So the `DT` install is now dead weight — an unused package installed on every render (and inherited by every downstream book). This removes it.

## Changes

- `publish.yml` / `preview.yml` — drop `any::DT` from the `setup-r-dependencies` package list.
- `copilot-setup-steps.yml` — drop `"DT"` from the `install.packages()` list.

## Test plan

- [ ] This PR's preview render still succeeds (the rendered pages — chapters + index — don't use DT).
- [ ] After merge, `Quarto Publish` on `main` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)