### PR TITLE
Poll for late-arriving @claude comments before ending agent sessions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -101,3 +101,16 @@ Before requesting review or marking work as complete:
 - **Fix any rendering issues** before requesting review.
 
 This ensures reviewers see working, polished output rather than discovering basic rendering problems.
+
+### Check for Late-Arriving Comments
+
+Before declaring an agent session complete, re-read the issue/PR thread for
+comments that were posted *after* the request you started on. A follow-up or
+correction can land while you're working, and ending the session without it
+means the next reviewer has to re-ask.
+
+- Re-check the timeline (and, on a PR, the inline review-thread comments) for
+  newer messages directed at you.
+- Address any in-chronological-order, then look again, until none remain.
+- If comments keep arriving, say so in your closing reply and stop rather than
+  looping indefinitely.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -111,6 +111,7 @@ means the next reviewer has to re-ask.
 
 - Re-check the timeline (and, on a PR, the inline review-thread comments) for
   newer messages directed at you.
-- Address any in-chronological-order, then look again, until none remain.
-- If comments keep arriving, say so in your closing reply and stop rather than
-  looping indefinitely.
+- Address any in chronological order, then look again, until none remain.
+- If comments keep arriving, stop after roughly five passes (mirroring the
+  cap in `claude.yml`), say so in your closing reply, and don't loop
+  indefinitely.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,13 +14,14 @@
 #     replies (questions/reviews) that agent mode would otherwise discard.
 #   - "Dispatch claude-code-review.yml on @claude review" routes review
 #     requests to the dedicated reviewer instead of self-reviewing.
+# Ported from d-morrison/rme (#788/#794/#805); adapted to qwt's lighter
+# setup (DESCRIPTION-based deps, no renv; no submodule-token URL rewrite).
+#
 # The `prompt:` also has Claude poll for late-arriving @claude comments
 # (issue/PR comment + PR review endpoints) before declaring done, so a
 # follow-up posted mid-run is handled in-session rather than dropped
 # (issue #73). The concurrency block serializes runs, but a queued run can
 # still re-handle a comment the active run already absorbed.
-# Ported from d-morrison/rme (#788/#794/#805); adapted to qwt's lighter
-# setup (DESCRIPTION-based deps, no renv; no submodule-token URL rewrite).
 #
 # Project guidance for Claude lives in CLAUDE.md at the repo root.
 
@@ -206,7 +207,7 @@ jobs:
 
             1. Fetch the endpoint(s) that apply to your trigger type. The
                URLs are NOT quoted — the allowed-tools pattern
-               `Bash(gh api repos/<repo>/*)` only matches the unquoted form,
+               `Bash(gh api repos/<repo>/:*)` only matches the unquoted form,
                and a leading quote (`gh api 'repos/...`) makes the call get
                denied:
                ```
@@ -244,15 +245,25 @@ jobs:
           # project R code that can `system()`; the real containment is the
           # trusted-author gate in the job `if:` above.
           #
-          # `Bash(gh api repos/${{ github.repository }}/*)` backs the
+          # `Bash(gh api repos/${{ github.repository }}/:*)` backs the
           # late-comment polling step in the prompt above (fetching
           # `/issues/N/comments`, `/pulls/N/comments`, `/pulls/N/reviews`).
-          # It's scoped to THIS repo's API surface — excludes cross-repo /
-          # cross-org calls the session doesn't need. It does match write
-          # endpoints (`gh api -X POST ...`) since allowed-tools can't filter
-          # by HTTP method, but the real bound is the GITHUB_TOKEN scopes.
+          # The `:*` (qwt's house prefix-wildcard, not a bare `/*` glob)
+          # matches `gh api repos/<this-repo>/` followed by any path — so it
+          # doesn't depend on whether `*` crosses `/`, and it's scoped to
+          # THIS repo's API surface (excludes cross-repo / cross-org calls).
+          #
+          # Because the prefix is anchored at `gh api repos/`, the flag-first
+          # write form (`gh api -X POST repos/...`) does NOT match this allow
+          # rule and is denied. The two `gh api -X` / `--method` entries in
+          # disallowedTools below also deny that form explicitly. What this
+          # still can't pattern-block is a URL-first write that appends a
+          # method/field flag AFTER the URL (`gh api repos/<repo>/... -X
+          # POST`), since allowed-tools can't filter by HTTP method or by
+          # flags past the prefix — there, the real bound is the
+          # GITHUB_TOKEN scopes plus the trusted-author gate in the job `if:`.
           claude_args: |
-            --allowedTools "Bash(Rscript -e 'lintr::lint*'),Bash(Rscript -e 'devtools::check*'),Bash(Rscript -e 'devtools::document*'),Bash(Rscript -e 'pkgdown::build*'),Bash(quarto render:*),Bash(quarto check:*),Bash(git diff:*),Bash(git log:*),Bash(git status:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push origin:*),Bash(git push -u origin:*),Bash(gh api repos/${{ github.repository }}/*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue view:*)" --disallowedTools "Bash(git push --force:*),Bash(git push -f:*),Bash(git push --delete:*),Bash(git push -d:*),Bash(git push --mirror:*),Bash(git push --tags:*),Bash(git push --all:*),Bash(git push origin +*),Bash(git push -u origin +*)"
+            --allowedTools "Bash(Rscript -e 'lintr::lint*'),Bash(Rscript -e 'devtools::check*'),Bash(Rscript -e 'devtools::document*'),Bash(Rscript -e 'pkgdown::build*'),Bash(quarto render:*),Bash(quarto check:*),Bash(git diff:*),Bash(git log:*),Bash(git status:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push origin:*),Bash(git push -u origin:*),Bash(gh api repos/${{ github.repository }}/:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue view:*)" --disallowedTools "Bash(git push --force:*),Bash(git push -f:*),Bash(git push --delete:*),Bash(git push -d:*),Bash(git push --mirror:*),Bash(git push --tags:*),Bash(git push --all:*),Bash(git push origin +*),Bash(git push -u origin +*),Bash(gh api -X:*),Bash(gh api --method:*)"
 
       # Fetch the PR's head SHA once, post-Claude, for the two steps that
       # both need it (the prose-post COMMITTED check and the re-request

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,6 +14,11 @@
 #     replies (questions/reviews) that agent mode would otherwise discard.
 #   - "Dispatch claude-code-review.yml on @claude review" routes review
 #     requests to the dedicated reviewer instead of self-reviewing.
+# The `prompt:` also has Claude poll for late-arriving @claude comments
+# (issue/PR comment + PR review endpoints) before declaring done, so a
+# follow-up posted mid-run is handled in-session rather than dropped
+# (issue #73). The concurrency block serializes runs, but a queued run can
+# still re-handle a comment the active run already absorbed.
 # Ported from d-morrison/rme (#788/#794/#805); adapted to qwt's lighter
 # setup (DESCRIPTION-based deps, no renv; no submodule-token URL rewrite).
 #
@@ -180,6 +185,56 @@ jobs:
             review; a post-step dispatches the dedicated code-review
             workflow instead.
 
+            **Before declaring the task complete, check for additional
+            @claude requests that arrived after the triggering event**, so a
+            follow-up posted while you were working gets handled in this same
+            session instead of being dropped (the per-PR/issue concurrency
+            group serializes runs, but a long session can still miss a
+            comment posted mid-run).
+
+            This run was triggered by a `${{ github.event_name }}` event.
+            Pre-resolved context (don't re-derive these):
+            - PR context? `${{ (github.event.pull_request.number || github.event.issue.pull_request) && 'yes' || 'no' }}`
+              (`issue_comment` fires for both issues and PRs; this flag
+              disambiguates without guessing.)
+            - Entity number: `${{ github.event.issue.number || github.event.pull_request.number }}`
+            - Triggering timestamp: `${{ github.event.comment.created_at || github.event.review.submitted_at || github.event.issue.created_at }}`
+              (`comment.created_at` for the comment events, `submitted_at`
+              for `pull_request_review`, `issue.created_at` for
+              `issues:opened` — this workflow does not trigger on
+              `issues:assigned`, so no coarser fallback is needed.)
+
+            1. Fetch the endpoint(s) that apply to your trigger type. The
+               URLs are NOT quoted — the allowed-tools pattern
+               `Bash(gh api repos/<repo>/*)` only matches the unquoted form,
+               and a leading quote (`gh api 'repos/...`) makes the call get
+               denied:
+               ```
+               gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number || github.event.pull_request.number }}/comments --paginate
+               gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number || github.event.pull_request.number }}/comments --paginate   # PRs only
+               gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number || github.event.pull_request.number }}/reviews  --paginate   # PRs only
+               ```
+               For **issue** triggers poll only `/issues/N/comments`; the
+               `/pulls/...` endpoints don't apply. `/issues/N/comments` holds
+               PR/issue timeline comments; `/pulls/N/comments` holds inline
+               review-thread comments; `/pulls/N/reviews` holds review
+               submissions (where `@claude` lives for a
+               `pull_request_review` trigger). The issue/PR body itself is
+               already supplied to you above — no need to re-fetch it.
+
+            2. Keep entries where ALL hold: the relevant timestamp
+               (`created_at` for comments, `submitted_at` for reviews) is
+               strictly after the triggering timestamp above; the text
+               (`body`) contains `@claude`; and `user.type` is not `"Bot"`
+               (excludes claude[bot], github-actions[bot], etc. so the loop
+               can't be driven by a bot that learns to say `@claude`).
+
+            3. If any match, address each in chronological order, then repeat
+               from step 1. Stop when none remain, or after at most **5**
+               polling iterations — whichever comes first. If you hit the cap
+               with comments still arriving, note it in your final message
+               and stop; the next queued run picks up from there.
+
           # Allowed git/gh/quarto/Rscript commands. `git push` is narrowed to
           # `origin` and destructive flag/refspec variants are denied so the
           # write-scoped token can't rewrite or delete refs. `Rscript -e` is
@@ -188,8 +243,16 @@ jobs:
           # accepting that quarto (like devtools::check/pkgdown::build) runs
           # project R code that can `system()`; the real containment is the
           # trusted-author gate in the job `if:` above.
+          #
+          # `Bash(gh api repos/${{ github.repository }}/*)` backs the
+          # late-comment polling step in the prompt above (fetching
+          # `/issues/N/comments`, `/pulls/N/comments`, `/pulls/N/reviews`).
+          # It's scoped to THIS repo's API surface — excludes cross-repo /
+          # cross-org calls the session doesn't need. It does match write
+          # endpoints (`gh api -X POST ...`) since allowed-tools can't filter
+          # by HTTP method, but the real bound is the GITHUB_TOKEN scopes.
           claude_args: |
-            --allowedTools "Bash(Rscript -e 'lintr::lint*'),Bash(Rscript -e 'devtools::check*'),Bash(Rscript -e 'devtools::document*'),Bash(Rscript -e 'pkgdown::build*'),Bash(quarto render:*),Bash(quarto check:*),Bash(git diff:*),Bash(git log:*),Bash(git status:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push origin:*),Bash(git push -u origin:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue view:*)" --disallowedTools "Bash(git push --force:*),Bash(git push -f:*),Bash(git push --delete:*),Bash(git push -d:*),Bash(git push --mirror:*),Bash(git push --tags:*),Bash(git push --all:*),Bash(git push origin +*),Bash(git push -u origin +*)"
+            --allowedTools "Bash(Rscript -e 'lintr::lint*'),Bash(Rscript -e 'devtools::check*'),Bash(Rscript -e 'devtools::document*'),Bash(Rscript -e 'pkgdown::build*'),Bash(quarto render:*),Bash(quarto check:*),Bash(git diff:*),Bash(git log:*),Bash(git status:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push origin:*),Bash(git push -u origin:*),Bash(gh api repos/${{ github.repository }}/*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue view:*)" --disallowedTools "Bash(git push --force:*),Bash(git push -f:*),Bash(git push --delete:*),Bash(git push -d:*),Bash(git push --mirror:*),Bash(git push --tags:*),Bash(git push --all:*),Bash(git push origin +*),Bash(git push -u origin +*)"
 
       # Fetch the PR's head SHA once, post-Claude, for the two steps that
       # both need it (the prose-post COMMITTED check and the re-request


### PR DESCRIPTION
## Summary

Closes #73.

A long-running `@claude` agent session could finish before a follow-up `@claude` comment posted *while it was working* was seen, dropping that request. The per-PR/issue `concurrency:` group serializes runs but doesn't help an already-active session notice newer comments.

- **`.github/workflows/claude.yml`** — adds a late-comment polling section to the agent `prompt:` (ported from `d-morrison/rme`, trimmed to qwt's trigger set; qwt does not fire on `issues:assigned`, so the triggering-timestamp cascade is simpler). Before declaring done, the agent polls the endpoints that apply to its trigger type (`/issues/N/comments`, plus `/pulls/N/comments` and `/pulls/N/reviews` on PRs), keeps only entries newer than the trigger with `@claude` from a non-bot author, addresses them in chronological order, and repeats up to **5** iterations. Adds `Bash(gh api repos/${{ github.repository }}/*)` to `allowedTools` (scoped to this repo) so the poll calls aren't denied, plus header/inline comments explaining the behavior and its concurrency-interaction limitation.
- **`.github/copilot-instructions.md`** — adds an equivalent "Check for Late-Arriving Comments" subsection so Copilot agent sessions get the same guidance (the issue asked to apply this to both claude.yml and Copilot sessions).

Deliberately did **not** import rme's heavier dynamic-allowlist machinery — out of scope for this issue.

## Test plan

- [ ] YAML parses (verified locally with `yaml.safe_load`).
- [ ] Behavioral validation only happens in CI: trigger an `@claude` mention on an issue/PR after merge, post a second `@claude` comment mid-run, and confirm the session addresses both before finishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)