### PR TITLE
Add the "reprexes" skill (.claude/skills/reprexes)

### DIFF
--- a/.claude/skills/reprexes/SKILL.md
+++ b/.claude/skills/reprexes/SKILL.md
@@ -98,7 +98,8 @@ but nothing more.
   Copy the code and call `reprex::reprex()` (reads the clipboard by default),
   or point it at a file with `reprex(input = "/tmp/reprex.R")` (or a
   `tempfile(fileext = ".R")` path on non-Unix machines) — handy from a
-  non-interactive CLI session where there's no clipboard. Useful arguments:
+  non-interactive CLI session where there's no clipboard. Use it when the
+  output is destined for a PR comment or an upstream issue. Useful arguments:
   - `venue =` — output format:
     - `"gh"` — GitHub-flavored Markdown (default)
     - `"so"` / `"ds"` — Stack Overflow / Discourse
@@ -112,16 +113,15 @@ but nothing more.
   - `std_out_err = TRUE` — capture stdout/stderr too (e.g. `system()` /
     subprocess or C-level output that doesn't come back as normal R results).
   - `wd =` — set the working directory when the code needs one.
-  - Use this when the reprex is destined for a PR comment or an upstream
-    issue. Companion helpers handle "wild-caught" reprexes (all exported in
-    reprex 2.x): `reprex_clean()` (strip the `#>` output markers from a
-    rendered/pasted reprex, leaving runnable code), `reprex_rescue()`
-    (recover code from R-console output with `>`/`+` prompts), and
-    `reprex_invert()` (the inverse of `reprex()` — recover the input code
-    from a rendered reprex).
   - Validation bonus: because `reprex()` runs in a fresh session, if it errors
     on a missing object or package, your example wasn't actually
     self-contained — fix that before sharing.
+
+  Companion helpers handle "wild-caught" reprexes (all exported in reprex
+  2.x): `reprex_clean()` (strip the `#>` output markers from a rendered/pasted
+  reprex, leaving runnable code), `reprex_rescue()` (recover code from
+  R-console output with `>`/`+` prompts), and `reprex_invert()` (the inverse
+  of `reprex()` — recover the input code from a rendered reprex).
 - When the bug might be **version-dependent**, capture `sessionInfo()` (or set
   `session_info = TRUE` above) in the reprex so versions are part of the
   record. If you suspect *stale* packages are the cause,

--- a/.claude/skills/reprexes/SKILL.md
+++ b/.claude/skills/reprexes/SKILL.md
@@ -57,8 +57,9 @@ but nothing more.
 1. **Hypothesize the minimal trigger.** What is the smallest combination of
    data + operation you believe causes the phenomenon?
 2. **Create a standalone scratch file** outside the repo tree (e.g.
-   `/tmp/reprex.R`, or a tiny `/tmp/reprex.qmd` for a render bug). Put in it,
-   in order:
+   `/tmp/reprex.R`, or a tiny `/tmp/reprex.qmd` for a render bug; on a
+   non-Unix machine use `tempfile(fileext = ".R")` / `tempdir()` for a
+   portable path). Put in it, in order:
    - the package loads (`library(...)`),
    - the minimal data (see tactics below),
    - the minimal code that triggers the phenomenon, with a comment marking
@@ -97,19 +98,24 @@ but nothing more.
   Copy the code and call `reprex::reprex()` (reads the clipboard by default),
   or point it at a file with `reprex(input = "/tmp/reprex.R")` — handy from a
   non-interactive CLI session where there's no clipboard. Useful arguments:
-  - `venue =` — output format: `"gh"` (GitHub-flavored Markdown, default),
-    `"so"`/`"ds"` (Stack Overflow / Discourse), `"slack"`, `"R"` (runnable
-    script with commented output), `"html"`, `"rtf"`.
+  - `venue =` — output format:
+    - `"gh"` — GitHub-flavored Markdown (default)
+    - `"so"` / `"ds"` — Stack Overflow / Discourse
+    - `"slack"` — Slack message
+    - `"r"` — runnable R script with commented output
+    - `"html"` — HTML
+    - `"rtf"` — rich text for presentations
   - `session_info = TRUE` — append `sessionInfo()` / `sessioninfo::session_info()`,
     so versions travel with the reprex (set this when the bug may be
     version-dependent).
-  - `std_out_err = TRUE` — capture stdout/stderr too (for output that doesn't
-    come back as normal R results).
+  - `std_out_err = TRUE` — capture stdout/stderr too (e.g. `system()` /
+    subprocess or C-level output that doesn't come back as normal R results).
   - `wd =` — set the working directory when the code needs one.
   - Use this when the reprex is destined for a PR comment or an upstream
-    issue. Companion helpers clean up "wild-caught" reprexes: `reprex_clean()`
-    (strip a GitHub/SO paste), `reprex_rescue()` (from console output), and
-    `reprex_invert()` (recover clean code from a rendered reprex).
+    issue. Companion helpers handle "wild-caught" reprexes: `reprex_clean()`
+    (strip the prompts/output from a copied reprex), `reprex_rescue()`
+    (recover code from R-console output with `>`/`+` prompts), and
+    `reprex_invert()` (turn a rendered reprex back into plain code).
   - Validation bonus: because `reprex()` runs in a fresh session, if it errors
     on a missing object or package, your example wasn't actually
     self-contained — fix that before sharing.

--- a/.claude/skills/reprexes/SKILL.md
+++ b/.claude/skills/reprexes/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: reprexes
+description: Isolate a technical problem into a minimal reproducible example ("reprex") and iterate fixes on that instead of inside the full application. Use when debugging a bug whose cause isn't obvious after a first look, when a failure only surfaces deep in a large pipeline / app / render, when the full-context test loop is slow, or before filing an upstream issue. Invoke explicitly with /reprexes.
+user-invocable: true
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+---
+
+# reprexes
+
+When a technical problem is hard to pin down, **don't debug it in the full
+context of the motivating application.** Extract a minimal, self-contained
+reproduction of the phenomenon, iterate candidate fixes on *that* (a fast,
+clean loop), then port the working fix back to the real code.
+
+Reference: <https://r4ds.hadley.nz/workflow-help.html#making-a-reprex>. The
+payoff is real: ~80% of the time, the act of building a thorough reprex
+surfaces the cause on its own — the noise you strip away was hiding it.
+
+## When this fires
+
+- A bug whose cause isn't obvious after a first read of the code.
+- A failure that only shows up deep inside a large pipeline, app, or a full
+  `quarto render` — where each reproduction attempt is slow.
+- Iterating on a fix that's expensive to test in the full context.
+- Before asking a human for help or filing an upstream/package issue — a
+  reprex is what they'll ask for anyway.
+
+Don't bother for a one-line obvious fix, or a problem you can already see and
+test cheaply in place.
+
+## The two requirements
+
+A reprex is only useful if it is BOTH:
+
+1. **Reproducible** — it captures *everything* needed to trigger the
+   phenomenon: every `library()` call, and code that creates every object it
+   uses. Someone (or a fresh session) can run it cold and see the same thing.
+2. **Minimal** — everything unrelated to the phenomenon is stripped out:
+   small or built-in data instead of the real dataset, only the lines that
+   matter.
+
+The tension between these two is the whole game: include enough to reproduce,
+but nothing more.
+
+## Procedure
+
+1. **Hypothesize the minimal trigger.** What is the smallest combination of
+   data + operation you believe causes the phenomenon?
+2. **Create a standalone scratch file** outside the repo tree (e.g.
+   `/tmp/reprex.R`, or a tiny `/tmp/reprex.qmd` for a render bug). Put in it,
+   in order:
+   - the package loads (`library(...)`),
+   - the minimal data (see tactics below),
+   - the minimal code that triggers the phenomenon, with a comment marking
+     where it goes wrong.
+3. **Run it in a clean session** and confirm it reproduces. For R, run with
+   `Rscript /tmp/reprex.R` (a fresh process — no stale `globalenv()` state
+   masking or faking the bug). For a Quarto page, render just that file:
+   `quarto render /tmp/reprex.qmd --to html`, not the whole site.
+4. **Minimize.** Remove pieces until the phenomenon disappears — the last
+   removal that "fixes" it implicates that piece. (Or build up from nothing
+   until it appears.) Keep the data as small as it can be while still failing.
+5. **Iterate fixes on the reprex**, not the full app. This is the fast loop
+   the whole technique exists to create.
+6. **Port the fix back** to the real code and verify it there.
+7. **Clean up.** Delete the scratch file (it lives in `/tmp`, so it never
+   touches the repo). If the bug was subtle, consider promoting the reprex
+   into a real regression test (`testthat`) instead of discarding it.
+
+## Minimizing the data
+
+- Prefer a **built-in dataset** (`mtcars`, `iris`, `mpg`) or a hand-built
+  tiny frame over the real data.
+- If you must use a slice of real data, serialize the minimal slice with
+  `dput()` so the reprex recreates it inline — no external file dependency.
+- Shrink to the fewest rows/columns that still show the phenomenon.
+
+## R / Quarto specifics
+
+- In R packages and Quarto projects, reprexes are usually short R snippets or
+  a single standalone `.qmd` page. Respect the repo's lint config
+  (`.lintr` / `.lintr.R`) if the reprex code will be ported back.
+- The **`reprex` package** (tidyverse, <https://reprex.tidyverse.org/>)
+  formats a reprex for sharing: it runs your code in a clean, separate R
+  session via `rmarkdown::render()` and emits code **plus actual output**.
+  Copy the code and call `reprex::reprex()` (reads the clipboard by default),
+  or point it at a file with `reprex(input = "/tmp/reprex.R")` — handy from a
+  non-interactive CLI session where there's no clipboard. Useful arguments:
+  - `venue =` — output format: `"gh"` (GitHub-flavored Markdown, default),
+    `"so"`/`"ds"` (Stack Overflow / Discourse), `"slack"`, `"R"` (runnable
+    script with commented output), `"html"`, `"rtf"`.
+  - `session_info = TRUE` — append `sessionInfo()` / `sessioninfo::session_info()`,
+    so versions travel with the reprex (set this when the bug may be
+    version-dependent).
+  - `std_out_err = TRUE` — capture stdout/stderr too (for output that doesn't
+    come back as normal R results).
+  - `wd =` — set the working directory when the code needs one.
+  - Use this when the reprex is destined for a PR comment or an upstream
+    issue. Companion helpers clean up "wild-caught" reprexes: `reprex_clean()`
+    (strip a GitHub/SO paste), `reprex_rescue()` (from console output), and
+    `reprex_invert()` (recover clean code from a rendered reprex).
+  - Validation bonus: because `reprex()` runs in a fresh session, if it errors
+    on a missing object or package, your example wasn't actually
+    self-contained — fix that before sharing.
+- When the bug might be **version-dependent**, capture `sessionInfo()` (or
+  run `tidyverse_update()`) in the reprex so versions are part of the record.
+- Build artifacts (`_site/`, `_freeze/`, `.quarto/`) are common confounders
+  for "it renders differently" bugs — a clean standalone render sidesteps
+  stale freeze caches.
+
+## Before declaring the reprex good
+
+- A fresh session runs it top-to-bottom and shows the phenomenon (and nothing
+  else breaks first).
+- It references no object, file, or option it didn't create itself.
+- It's as small as you can make it and still reproduce.
+
+## Don't
+
+- Don't paste the entire app/module — that's the opposite of a reprex.
+- Don't commit scratch reprex files; keep them in `/tmp` or a gitignored
+  scratch path.
+- Don't iterate fixes in the slow full-context loop once you have a reprex
+  that reproduces.

--- a/.claude/skills/reprexes/SKILL.md
+++ b/.claude/skills/reprexes/SKILL.md
@@ -97,7 +97,9 @@ but nothing more.
   output**.
   Copy the code and call `reprex::reprex()` (reads the clipboard by default),
   or point it at a file with `reprex(input = "/tmp/reprex.R")` — handy from a
-  non-interactive CLI session where there's no clipboard. Useful arguments:
+  non-interactive CLI session where there's no clipboard.
+  Use `reprex()` when the output is destined for a PR comment or an upstream
+  issue. Useful arguments:
   - `venue =` — output format:
     - `"gh"` — GitHub-flavored Markdown (default)
     - `"so"` / `"ds"` — Stack Overflow / Discourse
@@ -111,14 +113,14 @@ but nothing more.
   - `std_out_err = TRUE` — capture stdout/stderr too (e.g. `system()` /
     subprocess or C-level output that doesn't come back as normal R results).
   - `wd =` — set the working directory when the code needs one.
-  - Use this when the reprex is destined for a PR comment or an upstream
-    issue. Companion helpers handle "wild-caught" reprexes: `reprex_clean()`
-    (strip the prompts/output from a copied reprex), `reprex_rescue()`
-    (recover code from R-console output with `>`/`+` prompts), and
-    `reprex_invert()` (turn a rendered reprex back into plain code).
   - Validation bonus: because `reprex()` runs in a fresh session, if it errors
     on a missing object or package, your example wasn't actually
     self-contained — fix that before sharing.
+
+  Companion helpers handle "wild-caught" reprexes: `reprex_clean()` (strip
+  the prompts/output from a copied reprex), `reprex_rescue()` (recover code
+  from R-console output with `>`/`+` prompts), and `reprex_invert()` (turn a
+  rendered reprex back into plain code).
 - When the bug might be **version-dependent**, capture `sessionInfo()` (or set
   `session_info = TRUE` above) in the reprex so versions are part of the
   record. If you suspect *stale* packages are the cause, `tidyverse_update()`

--- a/.claude/skills/reprexes/SKILL.md
+++ b/.claude/skills/reprexes/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: reprexes
-description: >
-  Isolate a technical problem into a minimal reproducible example ("reprex") and iterate fixes on that instead of inside the full application.
-  Use when debugging a bug whose cause isn't obvious after a first look, when a failure only surfaces deep in a large pipeline / app / render, when the full-context test loop is slow, or before filing an upstream issue.
-  Invoke explicitly with /reprexes.
+description: Isolate a technical problem into a minimal reproducible example ("reprex") and iterate fixes on that instead of inside the full application. Use when debugging a bug whose cause isn't obvious after a first look, when a failure only surfaces deep in a large pipeline / app / render, when the full-context test loop is slow, or before filing an upstream issue. Invoke explicitly with /reprexes.
 user-invocable: true
 allowed-tools:
   - Bash
@@ -14,92 +11,118 @@ allowed-tools:
 
 # reprexes
 
-When a technical problem is hard to pin down, **don't debug it in the full context of the motivating application.**
-Extract a minimal, self-contained reproduction of the phenomenon, iterate candidate fixes on *that* (a fast, clean loop), then port the working fix back to the real code.
+When a technical problem is hard to pin down, **don't debug it in the full
+context of the motivating application.** Extract a minimal, self-contained
+reproduction of the phenomenon, iterate candidate fixes on *that* (a fast,
+clean loop), then port the working fix back to the real code.
 
-Reference: <https://r4ds.hadley.nz/workflow-help.html#making-a-reprex>.
-The payoff is real:
-~80% of the time, the act of building a thorough reprex surfaces the cause on its own — the noise you strip away was hiding it.
+Reference: <https://r4ds.hadley.nz/workflow-help.html#making-a-reprex>. The
+payoff is real: often, the act of building a thorough reprex surfaces the
+cause on its own — the noise you strip away was hiding it.
 
 ## When this fires
 
 - A bug whose cause isn't obvious after a first read of the code.
-- A failure that only shows up deep inside a large pipeline, app, or a full `quarto render` — where each reproduction attempt is slow.
+- A failure that only shows up deep inside a large pipeline, app, or a full
+  `quarto render` — where each reproduction attempt is slow.
 - Iterating on a fix that's expensive to test in the full context.
-- Before asking a human for help or filing an upstream/package issue — a reprex is what they'll ask for anyway.
+- Before asking a human for help or filing an upstream/package issue — a
+  reprex is what they'll ask for anyway.
 
-Don't bother for a one-line obvious fix, or a problem you can already see and test cheaply in place.
+Don't bother for a one-line obvious fix, or a problem you can already see and
+test cheaply in place.
 
 ## The two requirements
 
 A reprex is only useful if it is BOTH:
 
-1. **Reproducible** — it captures *everything* needed to trigger the phenomenon: every `library()` call, and code that creates every object it uses.
-   Someone (or a fresh session) can run it cold and see the same thing.
-2. **Minimal** — everything unrelated to the phenomenon is stripped out: small or built-in data instead of the real dataset, only the lines that matter.
+1. **Reproducible** — it captures *everything* needed to trigger the
+   phenomenon: every `library()` call, and code that creates every object it
+   uses. Someone (or a fresh session) can run it cold and see the same thing.
+2. **Minimal** — everything unrelated to the phenomenon is stripped out:
+   small or built-in data instead of the real dataset, only the lines that
+   matter.
 
-The tension between these two is the whole game: include enough to reproduce, but nothing more.
+The tension between these two is the whole game: include enough to reproduce,
+but nothing more.
 
 ## Procedure
 
-1. **Hypothesize the minimal trigger.**
-   What is the smallest combination of data + operation you believe causes the phenomenon?
-2. **Create a standalone scratch file** outside the repo tree (e.g. `/tmp/reprex.R`, or a tiny `/tmp/reprex.qmd` for a render bug).
-   Put in it, in order:
+1. **Hypothesize the minimal trigger.** What is the smallest combination of
+   data + operation you believe causes the phenomenon?
+2. **Create a standalone scratch file** outside the repo tree (e.g.
+   `/tmp/reprex.R`, or a tiny `/tmp/reprex.qmd` for a render bug). Put in it,
+   in order:
    - the package loads (`library(...)`),
    - the minimal data (see tactics below),
-   - the minimal code that triggers the phenomenon, with a comment marking where it goes wrong.
-3. **Run it in a clean session** and confirm it reproduces.
-   For R, run with `Rscript /tmp/reprex.R` (a fresh process — no stale `globalenv()` state masking or faking the bug).
-   For a Quarto page, render just that file: `quarto render /tmp/reprex.qmd --to html`, not the whole site.
-4. **Minimize.**
-   Remove pieces until the phenomenon disappears — the last removal that "fixes" it implicates that piece.
-   (Or build up from nothing until it appears.)
-   Keep the data as small as it can be while still failing.
-5. **Iterate fixes on the reprex**, not the full app.
-   This is the fast loop the whole technique exists to create.
+   - the minimal code that triggers the phenomenon, with a comment marking
+     where it goes wrong.
+3. **Run it in a clean session** and confirm it reproduces. For R, run with
+   `Rscript /tmp/reprex.R` (a fresh process — no stale `globalenv()` state
+   masking or faking the bug). For a Quarto page, render just that file:
+   `quarto render /tmp/reprex.qmd --to html`, not the whole site.
+4. **Minimize.** Remove pieces until the phenomenon disappears — the last
+   removal that "fixes" it implicates that piece. (Or build up from nothing
+   until it appears.) Keep the data as small as it can be while still failing.
+5. **Iterate fixes on the reprex**, not the full app. This is the fast loop
+   the whole technique exists to create.
 6. **Port the fix back** to the real code and verify it there.
-7. **Clean up.**
-   Delete the scratch file (it lives in `/tmp`, so it never touches the repo).
-   If the bug was subtle, consider promoting the reprex into a real regression test (`testthat`) instead of discarding it.
+7. **Clean up.** Delete the scratch file (it lives in `/tmp`, so it never
+   touches the repo). If the bug was subtle, consider promoting the reprex
+   into a real regression test (`testthat`) instead of discarding it.
 
 ## Minimizing the data
 
-- Prefer a **built-in dataset** (`mtcars`, `iris`, `mpg`) or a hand-built tiny frame over the real data.
-- If you must use a slice of real data, serialize the minimal slice with `dput()` so the reprex recreates it inline — no external file dependency.
+- Prefer a **built-in dataset** (`mtcars`, `mpg`) or a hand-built
+  tiny frame over the real data.
+- If you must use a slice of real data, serialize the minimal slice with
+  `dput()` so the reprex recreates it inline — no external file dependency.
 - Shrink to the fewest rows/columns that still show the phenomenon.
 
 ## R / Quarto specifics
 
-- In R packages and Quarto projects, reprexes are usually short R snippets or a single standalone `.qmd` page.
-  Respect the repo's lint config (`.lintr` / `.lintr.R`) if the reprex code will be ported back.
-- The **`reprex` package** (tidyverse, <https://reprex.tidyverse.org/>) formats a reprex for sharing: it runs your code in a clean, separate R session via `rmarkdown::render()` and emits code **plus actual output**.
-  Copy the code and call `reprex::reprex()` (reads the clipboard by default), or point it at a file with `reprex(input = "/tmp/reprex.R")` — handy from a non-interactive CLI session where there's no clipboard.
-  Useful arguments:
-  - `venue =` — output format:
-    - `"gh"` — GitHub-flavored Markdown (default)
-    - `"so"` / `"ds"` — Stack Overflow / Discourse
-    - `"slack"`
-    - `"R"` — runnable script with commented output
-    - `"html"`
-    - `"rtf"`
-  - `session_info = TRUE` — append `sessionInfo()` / `sessioninfo::session_info()`, so versions travel with the reprex (set this when the bug may be version-dependent).
-  - `std_out_err = TRUE` — capture stdout/stderr too (for output that doesn't come back as normal R results).
+- In R packages and Quarto projects, reprexes are usually short R snippets or
+  a single standalone `.qmd` page. Respect the repo's lint config
+  (`.lintr` / `.lintr.R`) if the reprex code will be ported back.
+- The **`reprex` package** (tidyverse, <https://reprex.tidyverse.org/>)
+  formats a reprex for sharing: it runs your code in a clean, separate R
+  session via `rmarkdown::render()` and emits code **plus actual output**.
+  Copy the code and call `reprex::reprex()` (reads the clipboard by default),
+  or point it at a file with `reprex(input = "/tmp/reprex.R")` — handy from a
+  non-interactive CLI session where there's no clipboard. Useful arguments:
+  - `venue =` — output format: `"gh"` (GitHub-flavored Markdown, default),
+    `"so"`/`"ds"` (Stack Overflow / Discourse), `"slack"`, `"R"` (runnable
+    script with commented output), `"html"`, `"rtf"`.
+  - `session_info = TRUE` — append `sessionInfo()` / `sessioninfo::session_info()`,
+    so versions travel with the reprex (set this when the bug may be
+    version-dependent).
+  - `std_out_err = TRUE` — capture stdout/stderr too (for output that doesn't
+    come back as normal R results).
   - `wd =` — set the working directory when the code needs one.
-  - Use this when the reprex is destined for a PR comment or an upstream issue.
-    Companion helpers clean up "wild-caught" reprexes: `reprex_clean()` (strip a GitHub/SO paste), `reprex_rescue()` (from console output), and `reprex_invert()` (recover clean code from a rendered reprex).
-  - Validation bonus: because `reprex()` runs in a fresh session, if it errors on a missing object or package, your example wasn't actually self-contained — fix that before sharing.
-- When the bug might be **version-dependent**, capture `sessionInfo()` or `sessioninfo::session_info()` output in the reprex so versions travel with the report.
-- Build artifacts (`_site/`, `_freeze/`, `.quarto/`) are common confounders for "it renders differently" bugs — a clean standalone render sidesteps stale freeze caches.
+  - Use this when the reprex is destined for a PR comment or an upstream
+    issue. Companion helpers clean up "wild-caught" reprexes: `reprex_clean()`
+    (strip a GitHub/SO paste), `reprex_rescue()` (from console output), and
+    `reprex_invert()` (recover clean code from a rendered reprex).
+  - Validation bonus: because `reprex()` runs in a fresh session, if it errors
+    on a missing object or package, your example wasn't actually
+    self-contained — fix that before sharing.
+- When the bug might be **version-dependent**, capture `sessionInfo()` (or
+  run `tidyverse_update()`) in the reprex so versions are part of the record.
+- Build artifacts (`_site/`, `_freeze/`, `.quarto/`) are common confounders
+  for "it renders differently" bugs — a clean standalone render sidesteps
+  stale freeze caches.
 
 ## Before declaring the reprex good
 
-- A fresh session runs it top-to-bottom and shows the phenomenon (and nothing else breaks first).
+- A fresh session runs it top-to-bottom and shows the phenomenon (and nothing
+  else breaks first).
 - It references no object, file, or option it didn't create itself.
 - It's as small as you can make it and still reproduce.
 
 ## Don't
 
 - Don't paste the entire app/module — that's the opposite of a reprex.
-- Don't commit scratch reprex files; keep them in `/tmp` or a gitignored scratch path.
-- Don't iterate fixes in the slow full-context loop once you have a reprex that reproduces.
+- Don't commit scratch reprex files; keep them in `/tmp` or a gitignored
+  scratch path.
+- Don't iterate fixes in the slow full-context loop once you have a reprex
+  that reproduces.

--- a/.claude/skills/reprexes/SKILL.md
+++ b/.claude/skills/reprexes/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: reprexes
-description: Isolate a technical problem into a minimal reproducible example ("reprex") and iterate fixes on that instead of inside the full application. Use when debugging a bug whose cause isn't obvious after a first look, when a failure only surfaces deep in a large pipeline / app / render, when the full-context test loop is slow, or before filing an upstream issue. Invoke explicitly with /reprexes.
+description: >
+  Isolate a technical problem into a minimal reproducible example ("reprex")
+  and iterate fixes on that instead of inside the full application. Use when
+  debugging a bug whose cause isn't obvious after a first look, when a failure
+  only surfaces deep in a large pipeline / app / render, when the full-context
+  test loop is slow, or before filing an upstream issue. Invoke explicitly
+  with /reprexes.
 user-invocable: true
 allowed-tools:
   - Bash
@@ -82,11 +88,12 @@ but nothing more.
 ## R / Quarto specifics
 
 - In R packages and Quarto projects, reprexes are usually short R snippets or
-  a single standalone `.qmd` page. Respect the repo's lint config
-  (`.lintr` / `.lintr.R`) if the reprex code will be ported back.
+  a single standalone `.qmd` page. Respect the repo's lint config if the
+  reprex code will be ported back.
 - The **`reprex` package** (tidyverse, <https://reprex.tidyverse.org/>)
   formats a reprex for sharing: it runs your code in a clean, separate R
-  session via `rmarkdown::render()` and emits code **plus actual output**.
+  session (via `callr` since reprex 2.0) and emits code **plus actual
+  output**.
   Copy the code and call `reprex::reprex()` (reads the clipboard by default),
   or point it at a file with `reprex(input = "/tmp/reprex.R")` — handy from a
   non-interactive CLI session where there's no clipboard. Useful arguments:
@@ -106,8 +113,11 @@ but nothing more.
   - Validation bonus: because `reprex()` runs in a fresh session, if it errors
     on a missing object or package, your example wasn't actually
     self-contained — fix that before sharing.
-- When the bug might be **version-dependent**, capture `sessionInfo()` (or
-  run `tidyverse_update()`) in the reprex so versions are part of the record.
+- When the bug might be **version-dependent**, capture `sessionInfo()` (or set
+  `session_info = TRUE` above) in the reprex so versions are part of the
+  record. If you suspect *stale* packages are the cause, `tidyverse_update()`
+  outside the reprex can rule that out — but it updates packages, it doesn't
+  record versions, so don't put it in the reprex itself.
 - Build artifacts (`_site/`, `_freeze/`, `.quarto/`) are common confounders
   for "it renders differently" bugs — a clean standalone render sidesteps
   stale freeze caches.

--- a/.claude/skills/reprexes/SKILL.md
+++ b/.claude/skills/reprexes/SKILL.md
@@ -16,8 +16,9 @@ context of the motivating application.** Extract a minimal, self-contained
 reproduction of the phenomenon, iterate candidate fixes on *that* (a fast,
 clean loop), then port the working fix back to the real code.
 
-Reference: <https://r4ds.hadley.nz/workflow-help.html#making-a-reprex>. The
-payoff is real: ~80% of the time, the act of building a thorough reprex
+Reference: <https://r4ds.hadley.nz/workflow-help.html#making-a-reprex>.
+The payoff is real:
+~80% of the time, the act of building a thorough reprex
 surfaces the cause on its own — the noise you strip away was hiding it.
 
 ## When this fires
@@ -106,8 +107,9 @@ but nothing more.
   - Validation bonus: because `reprex()` runs in a fresh session, if it errors
     on a missing object or package, your example wasn't actually
     self-contained — fix that before sharing.
-- When the bug might be **version-dependent**, capture `sessionInfo()` (or
-  run `tidyverse_update()`) in the reprex so versions are part of the record.
+- When the bug might be **version-dependent**,
+  capture `sessionInfo()` or `sessioninfo::session_info()` output in the reprex
+  so versions travel with the report.
 - Build artifacts (`_site/`, `_freeze/`, `.quarto/`) are common confounders
   for "it renders differently" bugs — a clean standalone render sidesteps
   stale freeze caches.

--- a/.claude/skills/reprexes/SKILL.md
+++ b/.claude/skills/reprexes/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: reprexes
-description: Isolate a technical problem into a minimal reproducible example ("reprex") and iterate fixes on that instead of inside the full application. Use when debugging a bug whose cause isn't obvious after a first look, when a failure only surfaces deep in a large pipeline / app / render, when the full-context test loop is slow, or before filing an upstream issue. Invoke explicitly with /reprexes.
+description: >
+  Isolate a technical problem into a minimal reproducible example ("reprex") and iterate fixes on that instead of inside the full application.
+  Use when debugging a bug whose cause isn't obvious after a first look, when a failure only surfaces deep in a large pipeline / app / render, when the full-context test loop is slow, or before filing an upstream issue.
+  Invoke explicitly with /reprexes.
 user-invocable: true
 allowed-tools:
   - Bash
@@ -11,120 +14,92 @@ allowed-tools:
 
 # reprexes
 
-When a technical problem is hard to pin down, **don't debug it in the full
-context of the motivating application.** Extract a minimal, self-contained
-reproduction of the phenomenon, iterate candidate fixes on *that* (a fast,
-clean loop), then port the working fix back to the real code.
+When a technical problem is hard to pin down, **don't debug it in the full context of the motivating application.**
+Extract a minimal, self-contained reproduction of the phenomenon, iterate candidate fixes on *that* (a fast, clean loop), then port the working fix back to the real code.
 
 Reference: <https://r4ds.hadley.nz/workflow-help.html#making-a-reprex>.
 The payoff is real:
-~80% of the time, the act of building a thorough reprex
-surfaces the cause on its own — the noise you strip away was hiding it.
+~80% of the time, the act of building a thorough reprex surfaces the cause on its own — the noise you strip away was hiding it.
 
 ## When this fires
 
 - A bug whose cause isn't obvious after a first read of the code.
-- A failure that only shows up deep inside a large pipeline, app, or a full
-  `quarto render` — where each reproduction attempt is slow.
+- A failure that only shows up deep inside a large pipeline, app, or a full `quarto render` — where each reproduction attempt is slow.
 - Iterating on a fix that's expensive to test in the full context.
-- Before asking a human for help or filing an upstream/package issue — a
-  reprex is what they'll ask for anyway.
+- Before asking a human for help or filing an upstream/package issue — a reprex is what they'll ask for anyway.
 
-Don't bother for a one-line obvious fix, or a problem you can already see and
-test cheaply in place.
+Don't bother for a one-line obvious fix, or a problem you can already see and test cheaply in place.
 
 ## The two requirements
 
 A reprex is only useful if it is BOTH:
 
-1. **Reproducible** — it captures *everything* needed to trigger the
-   phenomenon: every `library()` call, and code that creates every object it
-   uses. Someone (or a fresh session) can run it cold and see the same thing.
-2. **Minimal** — everything unrelated to the phenomenon is stripped out:
-   small or built-in data instead of the real dataset, only the lines that
-   matter.
+1. **Reproducible** — it captures *everything* needed to trigger the phenomenon: every `library()` call, and code that creates every object it uses.
+   Someone (or a fresh session) can run it cold and see the same thing.
+2. **Minimal** — everything unrelated to the phenomenon is stripped out: small or built-in data instead of the real dataset, only the lines that matter.
 
-The tension between these two is the whole game: include enough to reproduce,
-but nothing more.
+The tension between these two is the whole game: include enough to reproduce, but nothing more.
 
 ## Procedure
 
-1. **Hypothesize the minimal trigger.** What is the smallest combination of
-   data + operation you believe causes the phenomenon?
-2. **Create a standalone scratch file** outside the repo tree (e.g.
-   `/tmp/reprex.R`, or a tiny `/tmp/reprex.qmd` for a render bug). Put in it,
-   in order:
+1. **Hypothesize the minimal trigger.**
+   What is the smallest combination of data + operation you believe causes the phenomenon?
+2. **Create a standalone scratch file** outside the repo tree (e.g. `/tmp/reprex.R`, or a tiny `/tmp/reprex.qmd` for a render bug).
+   Put in it, in order:
    - the package loads (`library(...)`),
    - the minimal data (see tactics below),
-   - the minimal code that triggers the phenomenon, with a comment marking
-     where it goes wrong.
-3. **Run it in a clean session** and confirm it reproduces. For R, run with
-   `Rscript /tmp/reprex.R` (a fresh process — no stale `globalenv()` state
-   masking or faking the bug). For a Quarto page, render just that file:
-   `quarto render /tmp/reprex.qmd --to html`, not the whole site.
-4. **Minimize.** Remove pieces until the phenomenon disappears — the last
-   removal that "fixes" it implicates that piece. (Or build up from nothing
-   until it appears.) Keep the data as small as it can be while still failing.
-5. **Iterate fixes on the reprex**, not the full app. This is the fast loop
-   the whole technique exists to create.
+   - the minimal code that triggers the phenomenon, with a comment marking where it goes wrong.
+3. **Run it in a clean session** and confirm it reproduces.
+   For R, run with `Rscript /tmp/reprex.R` (a fresh process — no stale `globalenv()` state masking or faking the bug).
+   For a Quarto page, render just that file: `quarto render /tmp/reprex.qmd --to html`, not the whole site.
+4. **Minimize.**
+   Remove pieces until the phenomenon disappears — the last removal that "fixes" it implicates that piece.
+   (Or build up from nothing until it appears.)
+   Keep the data as small as it can be while still failing.
+5. **Iterate fixes on the reprex**, not the full app.
+   This is the fast loop the whole technique exists to create.
 6. **Port the fix back** to the real code and verify it there.
-7. **Clean up.** Delete the scratch file (it lives in `/tmp`, so it never
-   touches the repo). If the bug was subtle, consider promoting the reprex
-   into a real regression test (`testthat`) instead of discarding it.
+7. **Clean up.**
+   Delete the scratch file (it lives in `/tmp`, so it never touches the repo).
+   If the bug was subtle, consider promoting the reprex into a real regression test (`testthat`) instead of discarding it.
 
 ## Minimizing the data
 
-- Prefer a **built-in dataset** (`mtcars`, `iris`, `mpg`) or a hand-built
-  tiny frame over the real data.
-- If you must use a slice of real data, serialize the minimal slice with
-  `dput()` so the reprex recreates it inline — no external file dependency.
+- Prefer a **built-in dataset** (`mtcars`, `iris`, `mpg`) or a hand-built tiny frame over the real data.
+- If you must use a slice of real data, serialize the minimal slice with `dput()` so the reprex recreates it inline — no external file dependency.
 - Shrink to the fewest rows/columns that still show the phenomenon.
 
 ## R / Quarto specifics
 
-- In R packages and Quarto projects, reprexes are usually short R snippets or
-  a single standalone `.qmd` page. Respect the repo's lint config
-  (`.lintr` / `.lintr.R`) if the reprex code will be ported back.
-- The **`reprex` package** (tidyverse, <https://reprex.tidyverse.org/>)
-  formats a reprex for sharing: it runs your code in a clean, separate R
-  session via `rmarkdown::render()` and emits code **plus actual output**.
-  Copy the code and call `reprex::reprex()` (reads the clipboard by default),
-  or point it at a file with `reprex(input = "/tmp/reprex.R")` — handy from a
-  non-interactive CLI session where there's no clipboard. Useful arguments:
-  - `venue =` — output format: `"gh"` (GitHub-flavored Markdown, default),
-    `"so"`/`"ds"` (Stack Overflow / Discourse), `"slack"`, `"R"` (runnable
-    script with commented output), `"html"`, `"rtf"`.
-  - `session_info = TRUE` — append `sessionInfo()` / `sessioninfo::session_info()`,
-    so versions travel with the reprex (set this when the bug may be
-    version-dependent).
-  - `std_out_err = TRUE` — capture stdout/stderr too (for output that doesn't
-    come back as normal R results).
+- In R packages and Quarto projects, reprexes are usually short R snippets or a single standalone `.qmd` page.
+  Respect the repo's lint config (`.lintr` / `.lintr.R`) if the reprex code will be ported back.
+- The **`reprex` package** (tidyverse, <https://reprex.tidyverse.org/>) formats a reprex for sharing: it runs your code in a clean, separate R session via `rmarkdown::render()` and emits code **plus actual output**.
+  Copy the code and call `reprex::reprex()` (reads the clipboard by default), or point it at a file with `reprex(input = "/tmp/reprex.R")` — handy from a non-interactive CLI session where there's no clipboard.
+  Useful arguments:
+  - `venue =` — output format:
+    - `"gh"` — GitHub-flavored Markdown (default)
+    - `"so"` / `"ds"` — Stack Overflow / Discourse
+    - `"slack"`
+    - `"R"` — runnable script with commented output
+    - `"html"`
+    - `"rtf"`
+  - `session_info = TRUE` — append `sessionInfo()` / `sessioninfo::session_info()`, so versions travel with the reprex (set this when the bug may be version-dependent).
+  - `std_out_err = TRUE` — capture stdout/stderr too (for output that doesn't come back as normal R results).
   - `wd =` — set the working directory when the code needs one.
-  - Use this when the reprex is destined for a PR comment or an upstream
-    issue. Companion helpers clean up "wild-caught" reprexes: `reprex_clean()`
-    (strip a GitHub/SO paste), `reprex_rescue()` (from console output), and
-    `reprex_invert()` (recover clean code from a rendered reprex).
-  - Validation bonus: because `reprex()` runs in a fresh session, if it errors
-    on a missing object or package, your example wasn't actually
-    self-contained — fix that before sharing.
-- When the bug might be **version-dependent**,
-  capture `sessionInfo()` or `sessioninfo::session_info()` output in the reprex
-  so versions travel with the report.
-- Build artifacts (`_site/`, `_freeze/`, `.quarto/`) are common confounders
-  for "it renders differently" bugs — a clean standalone render sidesteps
-  stale freeze caches.
+  - Use this when the reprex is destined for a PR comment or an upstream issue.
+    Companion helpers clean up "wild-caught" reprexes: `reprex_clean()` (strip a GitHub/SO paste), `reprex_rescue()` (from console output), and `reprex_invert()` (recover clean code from a rendered reprex).
+  - Validation bonus: because `reprex()` runs in a fresh session, if it errors on a missing object or package, your example wasn't actually self-contained — fix that before sharing.
+- When the bug might be **version-dependent**, capture `sessionInfo()` or `sessioninfo::session_info()` output in the reprex so versions travel with the report.
+- Build artifacts (`_site/`, `_freeze/`, `.quarto/`) are common confounders for "it renders differently" bugs — a clean standalone render sidesteps stale freeze caches.
 
 ## Before declaring the reprex good
 
-- A fresh session runs it top-to-bottom and shows the phenomenon (and nothing
-  else breaks first).
+- A fresh session runs it top-to-bottom and shows the phenomenon (and nothing else breaks first).
 - It references no object, file, or option it didn't create itself.
 - It's as small as you can make it and still reproduce.
 
 ## Don't
 
 - Don't paste the entire app/module — that's the opposite of a reprex.
-- Don't commit scratch reprex files; keep them in `/tmp` or a gitignored
-  scratch path.
-- Don't iterate fixes in the slow full-context loop once you have a reprex
-  that reproduces.
+- Don't commit scratch reprex files; keep them in `/tmp` or a gitignored scratch path.
+- Don't iterate fixes in the slow full-context loop once you have a reprex that reproduces.

--- a/.claude/skills/reprexes/SKILL.md
+++ b/.claude/skills/reprexes/SKILL.md
@@ -22,8 +22,8 @@ context of the motivating application.** Extract a minimal, self-contained
 reproduction of the phenomenon, iterate candidate fixes on *that* (a fast,
 clean loop), then port the working fix back to the real code.
 
-Reference: <https://r4ds.hadley.nz/workflow-help.html#making-a-reprex>. The
-payoff is real: often, the act of building a thorough reprex surfaces the
+Reference: <https://r4ds.hadley.nz/workflow-help.html#making-a-reprex>.
+The payoff is real: often, the act of building a thorough reprex surfaces the
 cause on its own — the noise you strip away was hiding it.
 
 ## When this fires
@@ -96,10 +96,9 @@ but nothing more.
   session (via `callr` since reprex 2.0) and emits code **plus actual
   output**.
   Copy the code and call `reprex::reprex()` (reads the clipboard by default),
-  or point it at a file with `reprex(input = "/tmp/reprex.R")` — handy from a
-  non-interactive CLI session where there's no clipboard.
-  Use `reprex()` when the output is destined for a PR comment or an upstream
-  issue. Useful arguments:
+  or point it at a file with `reprex(input = "/tmp/reprex.R")` (or a
+  `tempfile(fileext = ".R")` path on non-Unix machines) — handy from a
+  non-interactive CLI session where there's no clipboard. Useful arguments:
   - `venue =` — output format:
     - `"gh"` — GitHub-flavored Markdown (default)
     - `"so"` / `"ds"` — Stack Overflow / Discourse
@@ -113,18 +112,21 @@ but nothing more.
   - `std_out_err = TRUE` — capture stdout/stderr too (e.g. `system()` /
     subprocess or C-level output that doesn't come back as normal R results).
   - `wd =` — set the working directory when the code needs one.
+  - Use this when the reprex is destined for a PR comment or an upstream
+    issue. Companion helpers handle "wild-caught" reprexes (all exported in
+    reprex 2.x): `reprex_clean()` (strip the `#>` output markers from a
+    rendered/pasted reprex, leaving runnable code), `reprex_rescue()`
+    (recover code from R-console output with `>`/`+` prompts), and
+    `reprex_invert()` (the inverse of `reprex()` — recover the input code
+    from a rendered reprex).
   - Validation bonus: because `reprex()` runs in a fresh session, if it errors
     on a missing object or package, your example wasn't actually
     self-contained — fix that before sharing.
-
-  Companion helpers handle "wild-caught" reprexes: `reprex_clean()` (strip
-  the prompts/output from a copied reprex), `reprex_rescue()` (recover code
-  from R-console output with `>`/`+` prompts), and `reprex_invert()` (turn a
-  rendered reprex back into plain code).
 - When the bug might be **version-dependent**, capture `sessionInfo()` (or set
   `session_info = TRUE` above) in the reprex so versions are part of the
-  record. If you suspect *stale* packages are the cause, `tidyverse_update()`
-  outside the reprex can rule that out — but it updates packages, it doesn't
+  record. If you suspect *stale* packages are the cause,
+  `tidyverse::tidyverse_update()` outside the reprex can rule that out — but it
+  updates packages, it doesn't
   record versions, so don't put it in the reprex itself.
 - Build artifacts (`_site/`, `_freeze/`, `.quarto/`) are common confounders
   for "it renders differently" bugs — a clean standalone render sidesteps
@@ -140,7 +142,7 @@ but nothing more.
 ## Don't
 
 - Don't paste the entire app/module — that's the opposite of a reprex.
-- Don't commit scratch reprex files; keep them in `/tmp` or a gitignored
-  scratch path.
+- Don't commit scratch reprex files; keep them in `/tmp` (or `tempdir()` on
+  non-Unix machines) or a gitignored scratch path.
 - Don't iterate fixes in the slow full-context loop once you have a reprex
   that reproduces.


### PR DESCRIPTION
## Summary

Adds a project-level Claude Code skill at `.claude/skills/reprexes/SKILL.md`.

**reprexes** captures a debugging workflow: when a technical problem is hard to pin down, isolate it into a minimal reproducible example ("reprex") and iterate candidate fixes on that fast, clean loop instead of inside the full application — then port the fix back. Includes the R/Quarto `reprex` package workflow (`reprex::reprex()`, `venue` / `session_info` / `std_out_err`).

References: <https://r4ds.hadley.nz/workflow-help.html#making-a-reprex>, <https://reprex.tidyverse.org/>.

Vendoring it here makes it available to collaborators and the `@claude` CI bot in this repo (previously it lived only in a personal user-level config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
