### PR TITLE
Post inline review comments; reply to inline comments in-thread

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -128,8 +128,12 @@ jobs:
                - Spell-check / link-check failures are fixed at the source
                  (wordlist or content) rather than suppressed.
 
-            Use inline comments for line-specific feedback. Skip generic
-            praise — be concrete. If the PR looks clean, say so briefly.
+            **Post line-specific findings as inline review comments** anchored
+            to the relevant line(s) — use the inline-comment tool, not a prose
+            list in the summary. Reserve the top-level summary comment for a
+            brief overall verdict plus any finding not tied to a specific line;
+            don't restate each inline comment there. Skip generic praise — be
+            concrete. If the PR looks clean, say so briefly.
 
           # `gh pr comment` is narrowed to `create` so the reviewer can post
           # a top-level summary but can't edit or delete prior review

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -180,7 +180,11 @@ jobs:
             If your reply is **prose** (answering a question, a
             recommendation, a review) rather than a code change, write your
             final message as the reply you want posted on the thread — a
-            post-step posts it as a comment when you didn't commit code.
+            post-step posts it as a comment when you didn't commit code. When
+            the trigger was an inline review comment on the diff (a
+            `pull_request_review_comment`), that reply is posted as a threaded
+            reply to that exact comment — keep it focused on the line(s) that
+            comment is about.
 
             For an explicit `@claude review` request, do NOT post your own
             review; a post-step dispatches the dedicated code-review
@@ -362,7 +366,20 @@ jobs:
           … (response truncated at ${MAX_LEN} bytes; full text in the [workflow run](${RUN_URL}))"
           fi
 
-          gh issue comment "$ENTITY_NUMBER" --repo "${{ github.repository }}" --body "$(printf '%s\n\n<sub>— posted by @claude post-step from [workflow run](%s)</sub>\n' "$RESPONSE" "$RUN_URL")" \
+          BODY="$(printf '%s\n\n<sub>— posted by @claude post-step from [workflow run](%s)</sub>\n' "$RESPONSE" "$RUN_URL")"
+          # When the trigger was an inline review comment, reply IN-THREAD to
+          # that comment (pulls/.../comments/<id>/replies) so the conversation
+          # stays anchored to the diff line instead of a detached top-level
+          # comment. Fall back to a top-level comment if the reply API fails
+          # (e.g. the parent review comment was deleted).
+          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            if jq -n --arg b "$BODY" '{body: $b}' \
+                 | gh api --method POST "repos/${{ github.repository }}/pulls/$ENTITY_NUMBER/comments/${{ github.event.comment.id }}/replies" --input - >/dev/null; then
+              exit 0
+            fi
+            echo "::warning::In-thread reply failed; falling back to a top-level comment."
+          fi
+          gh issue comment "$ENTITY_NUMBER" --repo "${{ github.repository }}" --body "$BODY" \
             || echo "::warning::Could not post Claude's response back to the source thread."
 
       # Route an explicit `@claude review` request to the dedicated reviewer


### PR DESCRIPTION
## Summary

Two related review-interaction improvements (enable + encourage):

**1. Code-review workflow → post inline comments.** The inline-comment tool + `pull-requests: write` were already available, but the upstream `/code-review:code-review` plugin defaulted to a top-level summary with *prose* line-references. Strengthened the review prompt to require line-specific findings be posted as **inline review comments** anchored to the line(s), reserving the top-level comment for a brief verdict + non-line-anchorable notes.

**2. Agent workflow → reply to inline comments in-thread.** When the agent is triggered by a `pull_request_review_comment` (an inline comment on the diff), the prose-reply post-step now replies **in-thread** via `POST /repos/{owner}/{repo}/pulls/{N}/comments/{comment_id}/replies` instead of a detached top-level `gh issue comment`. Top-level is kept for issue / review-summary / issue-comment triggers. Falls back to a top-level comment if the reply API fails (e.g. the parent comment was deleted). A prompt nudge tells Claude its reply lands in-thread so it stays focused on that line.

## Caveat

The review behavior is partly driven by the upstream plugin, so the inline-comment encouragement may only partly move it — worth confirming on a live PR; the wording can be iterated.

## Test plan

- [ ] YAML parses (verified locally).
- [ ] Open a PR and confirm the review posts real inline comments (not a prose list).
- [ ] Post an inline `@claude ...` review comment on a PR; confirm the reply lands as a threaded reply to that comment, not a top-level comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
