### PR TITLE
Enable Quarto llms-txt for the website

### DIFF
--- a/_quarto-website.yml
+++ b/_quarto-website.yml
@@ -17,6 +17,10 @@ website:
   title: "Quarto Website Template"
   site-url: https://ucd-serg.github.io/qwt/
   description: "A template for creating websites with Quarto"
+  # Generate llms.txt + per-page .llms.md for LLM-friendly consumption
+  # (https://quarto.org/docs/websites/website-llms.html). Key is `llms-txt`,
+  # not `llms`.
+  llms-txt: true
   page-footer:
     center: "Built with [Quarto](https://quarto.org/)"
   back-to-top-navigation: true

--- a/_quarto-website.yml
+++ b/_quarto-website.yml
@@ -17,9 +17,7 @@ website:
   title: "Quarto Website Template"
   site-url: https://ucd-serg.github.io/qwt/
   description: "A template for creating websites with Quarto"
-  # Generate llms.txt + per-page .llms.md for LLM-friendly consumption
-  # (https://quarto.org/docs/websites/website-llms.html). Key is `llms-txt`,
-  # not `llms`.
+  # https://quarto.org/docs/websites/website-llms.html — use `llms-txt:`, not `llms:` (schema error)
   llms-txt: true
   page-footer:
     center: "Built with [Quarto](https://quarto.org/)"


### PR DESCRIPTION
## Summary

Closes #69. Enables Quarto's LLM-friendly site output by adding `llms-txt: true` to the `website:` block in `_quarto-website.yml`. On render this produces `llms.txt` (a page index) at the site root plus a per-page `.llms.md` for each page.

**Note on the key:** it's `llms-txt: true`, **not** `llms: true`. I verified in a minimal throwaway Quarto site (Quarto 1.9.36) that `website: llms: true` fails schema validation (`property name llms is invalid`), while `llms-txt: true` renders successfully and emits `_site/llms.txt` + `*.llms.md`. (A prior attempt on this issue used `llms: true`, which would have broken the render.)

## Test plan

- [x] Reprex: minimal Quarto website with `llms-txt: true` renders and generates `llms.txt` + `.llms.md`.
- [ ] CI preview render of qwt produces `llms.txt` at the site root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)