### PR TITLE
Force LF for shell scripts via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Keep shell scripts LF so shebangs work on macOS/Linux regardless of
+# the contributor's platform or core.autocrlf setting.
+*.sh text eol=lf


### PR DESCRIPTION
## Summary

- `core.autocrlf=true` was rewriting `.github/scripts/apply-rulesets.sh` to CRLF on checkout, breaking its shebang (`env: bash\r: No such file or directory`) on macOS/Linux.
- The committed blob is already LF; this adds a `.gitattributes` rule pinning `*.sh` to `eol=lf` so checkouts stay LF regardless of the contributor's `autocrlf` setting.
- This is a template repo, so the rule propagates to downstream books created from it.

## Test plan

- [ ] Fresh checkout: `file .github/scripts/apply-rulesets.sh` reports LF (no CRLF)
- [ ] `bash .github/scripts/apply-rulesets.sh` runs without the `env: bash\r` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)