### PR TITLE
Fix @claude push auth: use token URL instead of persisted credentials

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -521,9 +521,19 @@ jobs:
 
       # Pair to "Set up branch for issue trigger": push the branch Claude
       # committed to and open a draft PR. Runs on always() so partial work
-      # is preserved even if the Claude step failed. qwt's checkout uses the
-      # persisted GITHUB_TOKEN (no submodule-token URL rewrite), so a plain
-      # `git push origin` authenticates — no token-bearing URL needed.
+      # is preserved even if the Claude step failed.
+      #
+      # The push uses an explicit token-bearing URL rather than relying on
+      # the credentials actions/checkout persists. The claude-code-action
+      # step that runs before this rewrites the repo's git auth config when
+      # it sets up its own credentials, leaving the main repo with no
+      # `http.https://github.com/.extraheader` — so a plain `git push origin`
+      # falls back to empty credentials and fails with "Password
+      # authentication is not supported" (run 26650131764). GITHUB_TOKEN has
+      # `contents: write` from the permissions block above, so it can push;
+      # note GitHub deliberately does NOT fire downstream workflows on a push
+      # authenticated by GITHUB_TOKEN, which is why the review is dispatched
+      # explicitly via `gh workflow run` below rather than left to a trigger.
       - name: Push branch and open draft PR for issue trigger
         if: |
           always() &&
@@ -551,7 +561,7 @@ jobs:
             exit 0
           fi
           echo "Pushing $BRANCH ($STARTING_SHA -> $CURRENT_SHA)"
-          git push origin "$BRANCH"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "$BRANCH"
           EXISTING=$(gh pr list --head "$BRANCH" --state open --json url --jq '.[0].url // empty')
           if [ -n "$EXISTING" ]; then
             echo "PR already exists for $BRANCH: $EXISTING"


### PR DESCRIPTION
## Why

`@claude` run [#26650131764](https://github.com/d-morrison/qwt/actions/runs/26650131764) (the bot's attempt to implement #101) did its work and committed, but **failed at the *"Push branch and open draft PR for issue trigger"* step** with:

```
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/d-morrison/qwt.git/'
```

So no draft PR was opened and the work was lost at runner cleanup.

## Root cause

The push step assumed `actions/checkout`'s persisted GITHUB_TOKEN credential would still be present and ran a plain `git push origin`. It isn't: the `anthropics/claude-code-action` step that runs *before* this one rewrites the repo's git auth config when it sets up its own credentials. The job-cleanup log confirms the main repo had **no** `http.https://github.com/.extraheader` by the end (only the `macros` submodule did), so the push fell back to empty credentials.

## Fix

Push with an explicit token-bearing URL built from `GITHUB_TOKEN` (which has `contents: write` from the job's `permissions:` block), so auth no longer depends on whatever the action left in git config:

```bash
git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "$BRANCH"
```

The downstream code review is already dispatched explicitly via `gh workflow run`, so GITHUB_TOKEN's deliberate "no recursive workflow trigger on push" behavior doesn't drop the review.

The stale comment that asserted a plain `git push origin` authenticates is replaced with one documenting the real failure mode and the GITHUB_TOKEN trigger caveat.

## Scope

Workflow-only; one push line + its comment. Does not touch #101's actual doc task — that issue remains open and can be re-attempted once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)