### PR TITLE
Assign repo owner as reviewer on Claude-opened PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -662,14 +662,9 @@ jobs:
               --body "$PR_BODY")
             echo "Opened draft PR: $PR_URL"
             PR_VERB="opened draft PR"
-            # Issue #105: request the repository owner as a reviewer on the
-            # freshly-opened PR so Claude's drafts land in their review queue.
-            # Done as a separate `gh pr edit` (not a `--reviewer` flag on
-            # `gh pr create`) so a reviewer-request failure — e.g. the owner
-            # is an org rather than a user, or happens to be the PR author —
-            # degrades to a warning instead of failing PR creation. Uses
-            # `github.repository_owner` so the request follows the repo into
-            # downstream books created from this template.
+            # Issue #105: request the repo owner as a reviewer. Separate from
+            # `gh pr create` so a failure (e.g. owner is an org) degrades to a
+            # warning rather than failing PR creation.
             gh pr edit "$PR_URL" --add-reviewer "${{ github.repository_owner }}" \
               || echo "::warning::Could not request ${{ github.repository_owner }} as a reviewer on $PR_URL."
           fi

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -662,6 +662,16 @@ jobs:
               --body "$PR_BODY")
             echo "Opened draft PR: $PR_URL"
             PR_VERB="opened draft PR"
+            # Issue #105: request the repository owner as a reviewer on the
+            # freshly-opened PR so Claude's drafts land in their review queue.
+            # Done as a separate `gh pr edit` (not a `--reviewer` flag on
+            # `gh pr create`) so a reviewer-request failure — e.g. the owner
+            # is an org rather than a user, or happens to be the PR author —
+            # degrades to a warning instead of failing PR creation. Uses
+            # `github.repository_owner` so the request follows the repo into
+            # downstream books created from this template.
+            gh pr edit "$PR_URL" --add-reviewer "${{ github.repository_owner }}" \
+              || echo "::warning::Could not request ${{ github.repository_owner }} as a reviewer on $PR_URL."
           fi
           # Dispatch a review on the new commits, for both the freshly-opened
           # and the already-exists (idempotent re-run) paths. The review's


### PR DESCRIPTION
## What

When the `claude.yml` workflow opens a draft PR for an issue trigger, it now requests the repository owner as a reviewer, so Claude's draft attempts land in the maintainer's review queue instead of sitting unnoticed.

## Why

Issue #105: "when claude creates a PR, assign me as a reviewer." Previously a Claude-opened PR had no reviewer assigned, so there was nothing to surface it in a review queue.

## How

In the "Push branch and open draft PR for issue trigger" step, after a PR is freshly opened, run:

```sh
gh pr edit "$PR_URL" --add-reviewer "${{ github.repository_owner }}"
```

- Uses `github.repository_owner` rather than a hard-coded username so the behavior follows the repo into downstream books created from this template.
- Implemented as a separate `gh pr edit` (rather than a `--reviewer` flag on `gh pr create`) and made non-fatal (`|| echo "::warning::..."`), so a reviewer-request error — e.g. the owner is an org rather than a user, or happens to be the PR author — degrades to a warning instead of failing the run.
- Only applies on the freshly-opened path; the "PR already exists" path leaves the existing reviewer assignment untouched.

Addresses #105.

https://claude.ai/code/session_01S2Cvpp3iGd7KSC9jWnDKxs

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2Cvpp3iGd7KSC9jWnDKxs)_