### PR TITLE
Allow claude bot to trigger PR review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -108,11 +108,13 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # When claude.yml routes an `@claude review` comment here, it
           # dispatches this workflow via `gh workflow run`, so the run's
-          # actor is github-actions[bot]. Without allowing that bot the
-          # action aborts with "Workflow initiated by non-human actor" and
-          # posts no review. The job `if:` already restricts dispatched runs
-          # to same-repo, non-Dependabot PRs, so accepting the bot here is safe.
-          allowed_bots: "github-actions[bot]"
+          # actor is github-actions[bot]. A `claude` remote session pushing
+          # a commit to a PR fires `synchronize` with the `claude` bot as
+          # actor. Without allowing these bots the action aborts with
+          # "Workflow initiated by non-human actor" and posts no review. The
+          # job `if:` already restricts runs to same-repo, non-Dependabot
+          # PRs, so accepting these bots here is safe.
+          allowed_bots: "github-actions[bot],claude"
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           # `claude-code-plugins` is a branch name, not a version tag.
           # Intentionally unpinned so we pick up future improvements to the


### PR DESCRIPTION
## What

Add `claude` to the `allowed_bots` list in `.github/workflows/claude-code-review.yml`, alongside the existing `github-actions[bot]` entry.

## Why

When a `claude` remote session pushes a commit to a PR, GitHub fires a `synchronize` event whose actor is the `claude` bot. `claude-code-action` aborts on any bot-initiated run unless that bot is allow-listed, so the `claude-review` check failed with:

```
Workflow initiated by non-human actor: claude (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

even though the diff was fine and every functional check (build-deploy, lint, spellcheck, link-check, DOIs) passed. This recurs on **any** PR where a Claude session pushes a commit, so it's a repo-wide CI gap rather than a one-off.

Surfaced on #110, where review-comment fixes pushed by a Claude session turned the review check red. Splitting the fix out keeps that PR scoped to its freezer change (and avoids tripping this workflow's own "skip self-review when the PR edits this file" guard).

## How

- `allowed_bots: "github-actions[bot]"` → `allowed_bots: "github-actions[bot],claude"`.
- Updated the adjacent comment to document the `claude`-push `synchronize` path.

The job's `if:` already restricts runs to same-repo, non-Dependabot PRs, so this doesn't widen who can trigger a review beyond trusted automation.

https://claude.ai/code/session_01S2Cvpp3iGd7KSC9jWnDKxs

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2Cvpp3iGd7KSC9jWnDKxs)_