### PR TITLE
ci: auto-update the macros submodule via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
 # Keep git submodules up to date automatically.
 #
 # This template embeds the shared `macros` repo as a git submodule. Dependabot's
-# `gitsubmodule` updater opens a PR whenever a submodule's tracked branch (here,
-# `main`) advances, so neither this template nor the books generated from it have
-# to bump the pointer by hand. See the ADR at d-morrison/macros
+# `gitsubmodule` updater opens a PR whenever a submodule's default branch
+# (currently `main`) advances, so neither this template nor the books generated
+# from it have to bump the pointer by hand. See the ADR at d-morrison/macros
 # (docs/adr/0001-macros-submodule-versioning.md) for why we track `main` rather
 # than a pinned release tag.
 version: 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Keep git submodules up to date automatically.
+#
+# This template embeds the shared `macros` repo as a git submodule. Dependabot's
+# `gitsubmodule` updater opens a PR whenever a submodule's tracked branch (here,
+# `main`) advances, so neither this template nor the books generated from it have
+# to bump the pointer by hand. See the ADR at d-morrison/macros
+# (docs/adr/0001-macros-submodule-versioning.md) for why we track `main` rather
+# than a pinned release tag.
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(submodule)"


### PR DESCRIPTION
## Summary

Adds a Dependabot config so the **`macros` submodule is bumped automatically** instead of by hand.

This template embeds `macros` as a submodule (tracking `main`). Dependabot's `gitsubmodule` updater opens a PR whenever that branch advances, removing the manual `git submodule update --remote` + commit step.

## Why this (and not a sliding tag)

Follow-through on the ADR in [`d-morrison/macros`](https://github.com/d-morrison/macros/blob/main/docs/adr/0001-macros-submodule-versioning.md): a sliding tag/branch wouldn't remove the manual bump, because a submodule gitlink only advances when a consumer updates *and commits* it. Dependabot is the automation that actually closes that loop — and it tracks a branch (`main`), the only ref that `--remote`-style tracking can follow.

## Template note

Because this is a template, the config propagates to books generated from it via "Use this template" — so downstream books also get hands-off `macros` updates. It adds no package/extension dependency, only a `.github/dependabot.yml`.

## Config

```yaml
package-ecosystem: "gitsubmodule"
directory: "/"
schedule: { interval: "weekly" }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrceBhXtcKRFaPPEMwxAZN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrceBhXtcKRFaPPEMwxAZN)_