### PR TITLE
ci: also auto-update GitHub Actions via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Keep git submodules up to date automatically.
+# Keep git submodules and pinned GitHub Actions up to date automatically.
 #
 # This template embeds the shared `macros` repo as a git submodule. Dependabot's
 # `gitsubmodule` updater opens a PR whenever a submodule's default branch
@@ -14,3 +14,13 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(submodule)"
+
+  # Also keep pinned GitHub Actions current. Dependabot scans .github/workflows/
+  # and opens a PR when a newer release of a pinned action is available;
+  # unversioned @HEAD / @main pins are left untouched.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(actions)"


### PR DESCRIPTION
## Summary

Follow-up to the merged Dependabot submodule PR ([#117](https://github.com/d-morrison/qwt/pull/117)). Adds a second Dependabot ecosystem, `github-actions`, so pinned action versions in `.github/workflows/` (e.g. `actions/checkout`, `r-lib/actions/*`, `quarto-dev/quarto-actions/*`) get bumped automatically too — including resolving the mixed `actions/checkout@v4`/`@v5` pins a reviewer noted.

Because this is a template, the config propagates to books generated from it.

## Config

```yaml
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule: { interval: "weekly" }
    commit-message: { prefix: "chore(actions)" }
```

Weekly cadence; unversioned `@HEAD`/`@main` pins are left untouched by Dependabot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrceBhXtcKRFaPPEMwxAZN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrceBhXtcKRFaPPEMwxAZN)_