### PR TITLE
Repoint gha reusable workflows to Morrison-Lab/gha

### DIFF
--- a/.github/workflows/check-bibliography-dois.yml
+++ b/.github/workflows/check-bibliography-dois.yml
@@ -1,10 +1,10 @@
 name: Check Bibliography DOIs
 
-# Thin caller for the shared reusable workflow in d-morrison/gha.
+# Thin caller for the shared reusable workflow in Morrison-Lab/gha.
 # The reusable workflow (and its bundled composite) reproduce the previous
 # standalone behavior: scan every *.bib in the repo and validate each DOI
 # resolves and matches its CrossRef metadata.
-# See https://github.com/d-morrison/gha for inputs and versioning.
+# See https://github.com/Morrison-Lab/gha for inputs and versioning.
 
 on:
   push:
@@ -20,4 +20,4 @@ jobs:
   check-dois:
     permissions:
       contents: read
-    uses: d-morrison/gha/.github/workflows/check-bibliography-dois.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/check-bibliography-dois.yml@v2

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,11 +1,11 @@
 name: Check Links
 
-# Thin caller for the shared reusable workflow in d-morrison/gha.
+# Thin caller for the shared reusable workflow in Morrison-Lab/gha.
 # The reusable workflow reproduces the previous standalone behavior: lychee
 # link check over .qmd/.md/.html, a PR skip-label ("links checked by hand"),
 # and auto-filing an issue when links break on main. We pass our repo-local
 # lychee.toml so the qwt-specific excludes (e.g. quarto.org) still apply.
-# See https://github.com/d-morrison/gha for inputs and versioning.
+# See https://github.com/Morrison-Lab/gha for inputs and versioning.
 
 on:
   push:
@@ -26,6 +26,6 @@ jobs:
       contents: read
       issues: write
       pull-requests: read
-    uses: d-morrison/gha/.github/workflows/check-links.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/check-links.yml@v2
     with:
       lychee-config: lychee.toml

--- a/.github/workflows/check-non-standard-chars.yaml
+++ b/.github/workflows/check-non-standard-chars.yaml
@@ -1,9 +1,9 @@
 name: Check Non-Standard Characters
 
-# Thin caller for the shared reusable workflow in d-morrison/gha.
+# Thin caller for the shared reusable workflow in Morrison-Lab/gha.
 # The reusable workflow (and its bundled composite) reproduce the previous
 # standalone behavior: detect curly quotes / en/em dashes in .qmd and .R files.
-# See https://github.com/d-morrison/gha for inputs and versioning.
+# See https://github.com/Morrison-Lab/gha for inputs and versioning.
 
 on:
   push:
@@ -20,4 +20,4 @@ jobs:
   check-chars:
     permissions:
       contents: read
-    uses: d-morrison/gha/.github/workflows/check-non-standard-chars.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/check-non-standard-chars.yml@v2


### PR DESCRIPTION
The `gha` repo moved from `d-morrison/gha` to `Morrison-Lab/gha`.

GitHub Actions does **not** follow repository-rename redirects for `uses:`, so
every call in this repo was failing to resolve before any job started. This
repoints all 9 reference(s) across 3 workflow file(s). Tags and paths
are unchanged.

Direct push to the default branch was blocked by repository rules, so this is a PR.